### PR TITLE
Fix project name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
-# undetheradar2
+# Under the Radar API
+
+This repository contains the sample code for the Under the Radar API.

--- a/app.js
+++ b/app.js
@@ -1,0 +1,11 @@
+const express = require('express');
+const app = express();
+
+app.get('/', (req, res) => {
+  res.send('Welcome to the Under the Radar API');
+});
+
+const port = process.env.PORT || 3000;
+app.listen(port, () => {
+  console.log(`Server is running on port ${port}`);
+});


### PR DESCRIPTION
## Summary
- update README title and description
- add a simple Express server with the corrected greeting

## Testing
- `npm init -y`
- `npm install express`
- `node app.js & pid=$!; sleep 1; curl -s http://localhost:3000/; kill $pid`

------
https://chatgpt.com/codex/tasks/task_e_68858035d9f8832dbb00378a543f0101