### PR TITLE
Add basic browser UI for API

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,10 @@ npm start
 
 The server listens on port `3000` by default.
 
+Once running, open [http://localhost:3000](http://localhost:3000) to use the
+included demo front end. The interface lets you create users, send messages and
+upload media using the API endpoints described below.
+
 ## Database
 
 The API uses **SQLite** for data storage. When you start the server for the

--- a/app.js
+++ b/app.js
@@ -1,5 +1,6 @@
 const express = require('express');
 const bodyParser = require('body-parser');
+const path = require('path');
 const { init } = require('./db');
 
 const usersRouter = require('./routes/users');
@@ -10,6 +11,7 @@ const app = express();
 const PORT = process.env.PORT || 3000;
 
 app.use(bodyParser.json());
+app.use(express.static(path.join(__dirname, 'public')));
 
 // Initialize database
 init();
@@ -19,7 +21,7 @@ app.use('/messages', messagesRouter);
 app.use('/media', mediaRouter);
 
 app.get('/', (req, res) => {
-  res.send('Welcome to the Unde the Radar API');
+  res.sendFile(path.join(__dirname, 'public', 'index.html'));
 });
 
 app.listen(PORT, () => {

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>Under the Radar UI</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <h1>Under the Radar</h1>
+  <section>
+    <h2>Create User</h2>
+    <input id="user-name" placeholder="Name">
+    <button id="create-user">Create</button>
+  </section>
+  <section>
+    <h2>Users</h2>
+    <button id="load-users">Load Users</button>
+    <pre id="users-output"></pre>
+  </section>
+  <section>
+    <h2>Send Message</h2>
+    <input id="sender-id" placeholder="Sender ID" type="number">
+    <input id="receiver-id" placeholder="Receiver ID" type="number">
+    <input id="message-content" placeholder="Content">
+    <button id="send-message">Send</button>
+  </section>
+  <section>
+    <h2>Messages</h2>
+    <button id="load-messages">Load Messages</button>
+    <pre id="messages-output"></pre>
+  </section>
+  <section>
+    <h2>Upload Media</h2>
+    <input id="media-file" type="file">
+    <button id="upload-media">Upload</button>
+  </section>
+  <section>
+    <h2>Media Files</h2>
+    <button id="load-media">Load Media</button>
+    <pre id="media-output"></pre>
+  </section>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/public/script.js
+++ b/public/script.js
@@ -1,0 +1,57 @@
+const output = (el, data) => {
+  document.getElementById(el).textContent = JSON.stringify(data, null, 2);
+};
+
+document.getElementById('create-user').onclick = async () => {
+  const name = document.getElementById('user-name').value;
+  if (!name) return alert('Name is required');
+  const res = await fetch('/users', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ name })
+  });
+  const data = await res.json();
+  output('users-output', data);
+};
+
+document.getElementById('load-users').onclick = async () => {
+  const res = await fetch('/users');
+  const data = await res.json();
+  output('users-output', data);
+};
+
+document.getElementById('send-message').onclick = async () => {
+  const sender_id = document.getElementById('sender-id').value;
+  const receiver_id = document.getElementById('receiver-id').value;
+  const content = document.getElementById('message-content').value;
+  if (!sender_id || !receiver_id || !content) return alert('All fields required');
+  const res = await fetch('/messages', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ sender_id, receiver_id, content })
+  });
+  const data = await res.json();
+  output('messages-output', data);
+};
+
+document.getElementById('load-messages').onclick = async () => {
+  const res = await fetch('/messages');
+  const data = await res.json();
+  output('messages-output', data);
+};
+
+document.getElementById('upload-media').onclick = async () => {
+  const fileInput = document.getElementById('media-file');
+  if (!fileInput.files[0]) return alert('File required');
+  const formData = new FormData();
+  formData.append('file', fileInput.files[0]);
+  const res = await fetch('/media', { method: 'POST', body: formData });
+  const data = await res.json();
+  output('media-output', data);
+};
+
+document.getElementById('load-media').onclick = async () => {
+  const res = await fetch('/media');
+  const data = await res.json();
+  output('media-output', data);
+};

--- a/public/style.css
+++ b/public/style.css
@@ -1,0 +1,12 @@
+body {
+  font-family: Arial, sans-serif;
+  margin: 20px;
+}
+section {
+  margin-bottom: 20px;
+  padding: 10px;
+  border: 1px solid #ccc;
+}
+button {
+  margin-left: 5px;
+}


### PR DESCRIPTION
## Summary
- expose `public` directory for static files
- create `index.html`, `style.css`, and `script.js` with simple forms for Users/Messages/Media
- document how to access the new demo UI in README

## Testing
- `npm install`
- `npm start`

------
https://chatgpt.com/codex/tasks/task_e_688586a844ac832db9ba433f360c2e84