### PR TITLE
Implement JWT authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,13 @@ artists with a simple place to:
 The backend is built with Node.js, Express and SQLite using CommonJS modules and
 minimal dependencies. Current endpoints include:
 
-- `GET /users` and `POST /users` – manage user profiles
-- `GET /messages` and `POST /messages` – send direct messages
-- `GET /media` and `POST /media` – upload and list media files
+- `POST /auth/register` – create an account
+- `POST /auth/login` – obtain a JWT
+- `GET /users` – list user profiles
+- `POST /users` – update the authenticated user's profile
+- `GET /users/:id` – fetch a user by id
+- `GET /messages` and `POST /messages` – list and send messages (sending requires authentication)
+- `GET /media` and `POST /media` – list and upload media files (upload requires authentication)
 
 Future additions will cover show listings, merch management and the message
 board. Everything is intentionally straightforward with no ranking algorithms.
@@ -49,41 +53,56 @@ root containing the required tables.
 
 ## API Endpoints
 
+### `/auth`
+
+- `POST /auth/register` – register a new user
+- `POST /auth/login` – log in and receive a token
+
+Example registration request:
+
+```bash
+curl -X POST http://localhost:3000/auth/register \
+  -H "Content-Type: application/json" \
+  -d '{"name":"Alice","username":"alice","password":"secret"}'
+```
+
+Example login request:
+
+```bash
+curl -X POST http://localhost:3000/auth/login \
+  -H "Content-Type: application/json" \
+  -d '{"username":"alice","password":"secret"}'
+```
+
 ### `/users`
 
 - `GET /users` – list all users
-- `POST /users` – create a new user
+- `POST /users` – update the authenticated user's profile
 - `GET /users/:id` – fetch a user by id
-
-Example request to create a user:
-
-```bash
-curl -X POST http://localhost:3000/users \
-  -H "Content-Type: application/json" \
-  -d '{"name":"Alice"}'
-```
 
 ### `/messages`
 
 - `GET /messages` – list all messages
-- `POST /messages` – send a new message
+- `POST /messages` – send a new message (requires authentication)
 
 Example request to send a message:
 
 ```bash
 curl -X POST http://localhost:3000/messages \
+  -H "Authorization: Bearer <TOKEN>" \
   -H "Content-Type: application/json" \
-  -d '{"sender_id":1,"receiver_id":2,"content":"Hello"}'
+  -d '{"receiver_id":2,"content":"Hello"}'
 ```
 
 ### `/media`
 
 - `GET /media` – list uploaded files
-- `POST /media` – upload a file using `multipart/form-data`
+- `POST /media` – upload a file using `multipart/form-data` (requires authentication)
 
 Example request to upload a file:
 
 ```bash
 curl -X POST http://localhost:3000/media \
+  -H "Authorization: Bearer <TOKEN>" \
   -F file=@path/to/image.png
 ```

--- a/app.js
+++ b/app.js
@@ -6,6 +6,7 @@ const { init } = require('./db');
 const usersRouter = require('./routes/users');
 const messagesRouter = require('./routes/messages');
 const mediaRouter = require('./routes/media');
+const authRouter = require('./routes/auth');
 
 const app = express();
 const PORT = process.env.PORT || 3000;
@@ -19,6 +20,7 @@ init();
 app.use('/users', usersRouter);
 app.use('/messages', messagesRouter);
 app.use('/media', mediaRouter);
+app.use('/auth', authRouter);
 
 app.get('/', (req, res) => {
   res.sendFile(path.join(__dirname, 'public', 'index.html'));

--- a/db.js
+++ b/db.js
@@ -7,7 +7,12 @@ const init = () => {
   db.serialize(() => {
     db.run(`CREATE TABLE IF NOT EXISTS users (
       id INTEGER PRIMARY KEY AUTOINCREMENT,
-      name TEXT NOT NULL
+      name TEXT NOT NULL,
+      username TEXT NOT NULL UNIQUE,
+      password TEXT NOT NULL,
+      email TEXT,
+      bio TEXT,
+      social TEXT
     )`);
 
     db.run(`CREATE TABLE IF NOT EXISTS messages (

--- a/middleware/auth.js
+++ b/middleware/auth.js
@@ -1,0 +1,13 @@
+const jwt = require('jsonwebtoken');
+const SECRET = process.env.JWT_SECRET || 'secret';
+
+module.exports = function authenticate(req, res, next) {
+  const header = req.headers['authorization'];
+  const token = header && header.split(' ')[1];
+  if (!token) return res.status(401).json({ error: 'Token required' });
+  jwt.verify(token, SECRET, (err, user) => {
+    if (err) return res.status(403).json({ error: 'Invalid token' });
+    req.user = user;
+    next();
+  });
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,10 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "bcryptjs": "^2.4.3",
         "body-parser": "^2.2.0",
         "express": "^5.1.0",
+        "jsonwebtoken": "^9.0.2",
         "multer": "^2.0.2",
         "sqlite3": "^5.1.7"
       }
@@ -196,6 +198,12 @@
       ],
       "license": "MIT"
     },
+    "node_modules/bcryptjs": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-2.4.3.tgz",
+      "integrity": "sha512-V/Hy/X9Vt7f3BbPJEi8BdVFMByHi+jNXrYkW3huaybV/kQ0KJg0Y6PkEMbn+zeT+i+SiKZ/HMqJGIIt4LZDqNQ==",
+      "license": "MIT"
+    },
     "node_modules/bindings": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
@@ -270,6 +278,12 @@
         "base64-js": "^1.3.1",
         "ieee754": "^1.1.13"
       }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/buffer-from": {
       "version": "1.1.2",
@@ -544,6 +558,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/ee-first": {
@@ -1124,6 +1147,91 @@
       "integrity": "sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A==",
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/jsonwebtoken": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.2.tgz",
+      "integrity": "sha512-PRp66vJ865SSqOlgqS8hujT5U4AOgMfhrwYIuIhfKaoSCZcirrmASQr8CX7cUg+RMih+hgznrjp99o+W4pJLHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "jws": "^3.2.2",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.2.tgz",
+      "integrity": "sha512-eeH5JO+21J78qMvTIDdBXidBd6nG2kZjg5Ohz/1fpa28Z4CcsWUzJ1ZZyFq/3z3N17aZy+ZuBoHljASbL1WfOw==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
+      "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^1.4.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
+      "license": "MIT"
     },
     "node_modules/lru-cache": {
       "version": "6.0.0",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,8 @@
     "body-parser": "^2.2.0",
     "express": "^5.1.0",
     "multer": "^2.0.2",
-    "sqlite3": "^5.1.7"
+    "sqlite3": "^5.1.7",
+    "bcryptjs": "^2.4.3",
+    "jsonwebtoken": "^9.0.2"
   }
 }

--- a/public/index.html
+++ b/public/index.html
@@ -8,9 +8,18 @@
 <body>
   <h1>Under the Radar</h1>
   <section>
-    <h2>Create User</h2>
-    <input id="user-name" placeholder="Name">
-    <button id="create-user">Create</button>
+    <h2>Register</h2>
+    <input id="reg-name" placeholder="Name">
+    <input id="reg-username" placeholder="Username">
+    <input id="reg-password" placeholder="Password" type="password">
+    <button id="register">Register</button>
+  </section>
+  <section>
+    <h2>Login</h2>
+    <input id="login-username" placeholder="Username">
+    <input id="login-password" placeholder="Password" type="password">
+    <button id="login">Login</button>
+    <p id="token-display"></p>
   </section>
   <section>
     <h2>Users</h2>
@@ -19,7 +28,6 @@
   </section>
   <section>
     <h2>Send Message</h2>
-    <input id="sender-id" placeholder="Sender ID" type="number">
     <input id="receiver-id" placeholder="Receiver ID" type="number">
     <input id="message-content" placeholder="Content">
     <button id="send-message">Send</button>

--- a/public/script.js
+++ b/public/script.js
@@ -1,16 +1,37 @@
+let token = null;
+
 const output = (el, data) => {
   document.getElementById(el).textContent = JSON.stringify(data, null, 2);
 };
 
-document.getElementById('create-user').onclick = async () => {
-  const name = document.getElementById('user-name').value;
-  if (!name) return alert('Name is required');
-  const res = await fetch('/users', {
+document.getElementById('register').onclick = async () => {
+  const name = document.getElementById('reg-name').value;
+  const username = document.getElementById('reg-username').value;
+  const password = document.getElementById('reg-password').value;
+  if (!name || !username || !password) return alert('All fields required');
+  const res = await fetch('/auth/register', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ name })
+    body: JSON.stringify({ name, username, password })
   });
   const data = await res.json();
+  if (data.token) token = data.token;
+  document.getElementById('token-display').textContent = token || '';
+  output('users-output', data);
+};
+
+document.getElementById('login').onclick = async () => {
+  const username = document.getElementById('login-username').value;
+  const password = document.getElementById('login-password').value;
+  if (!username || !password) return alert('Both fields required');
+  const res = await fetch('/auth/login', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ username, password })
+  });
+  const data = await res.json();
+  if (data.token) token = data.token;
+  document.getElementById('token-display').textContent = token || '';
   output('users-output', data);
 };
 
@@ -21,14 +42,14 @@ document.getElementById('load-users').onclick = async () => {
 };
 
 document.getElementById('send-message').onclick = async () => {
-  const sender_id = document.getElementById('sender-id').value;
   const receiver_id = document.getElementById('receiver-id').value;
   const content = document.getElementById('message-content').value;
-  if (!sender_id || !receiver_id || !content) return alert('All fields required');
+  if (!token) return alert('Login first');
+  if (!receiver_id || !content) return alert('All fields required');
   const res = await fetch('/messages', {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ sender_id, receiver_id, content })
+    headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+    body: JSON.stringify({ receiver_id, content })
   });
   const data = await res.json();
   output('messages-output', data);
@@ -43,9 +64,14 @@ document.getElementById('load-messages').onclick = async () => {
 document.getElementById('upload-media').onclick = async () => {
   const fileInput = document.getElementById('media-file');
   if (!fileInput.files[0]) return alert('File required');
+  if (!token) return alert('Login first');
   const formData = new FormData();
   formData.append('file', fileInput.files[0]);
-  const res = await fetch('/media', { method: 'POST', body: formData });
+  const res = await fetch('/media', {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${token}` },
+    body: formData
+  });
   const data = await res.json();
   output('media-output', data);
 };

--- a/routes/auth.js
+++ b/routes/auth.js
@@ -1,0 +1,41 @@
+const express = require('express');
+const bcrypt = require('bcryptjs');
+const jwt = require('jsonwebtoken');
+const { db } = require('../db');
+
+const router = express.Router();
+const SECRET = process.env.JWT_SECRET || 'secret';
+
+// Register a new user
+router.post('/register', (req, res) => {
+  const { name, username, password, email, bio, social } = req.body;
+  if (!name || !username || !password) {
+    return res.status(400).json({ error: 'name, username and password required' });
+  }
+  const hashed = bcrypt.hashSync(password, 10);
+  const stmt = `INSERT INTO users(name, username, password, email, bio, social) VALUES(?,?,?,?,?,?)`;
+  db.run(stmt, [name, username, hashed, email, bio, social], function(err) {
+    if (err) return res.status(500).json({ error: err.message });
+    const token = jwt.sign({ id: this.lastID, username }, SECRET);
+    res.json({ token, id: this.lastID });
+  });
+});
+
+// Login existing user
+router.post('/login', (req, res) => {
+  const { username, password } = req.body;
+  if (!username || !password) {
+    return res.status(400).json({ error: 'username and password required' });
+  }
+  db.get('SELECT * FROM users WHERE username = ?', [username], (err, user) => {
+    if (err) return res.status(500).json({ error: err.message });
+    if (!user) return res.status(400).json({ error: 'Invalid credentials' });
+    if (!bcrypt.compareSync(password, user.password)) {
+      return res.status(400).json({ error: 'Invalid credentials' });
+    }
+    const token = jwt.sign({ id: user.id, username: user.username }, SECRET);
+    res.json({ token, id: user.id });
+  });
+});
+
+module.exports = router;

--- a/routes/media.js
+++ b/routes/media.js
@@ -4,6 +4,7 @@ const multer = require('multer');
 const path = require('path');
 const fs = require('fs');
 const { db } = require('../db');
+const authenticate = require('../middleware/auth');
 
 const upload = multer({ dest: path.join(__dirname, '..', 'uploads') });
 
@@ -16,7 +17,7 @@ router.get('/', (req, res) => {
 });
 
 // Upload a new file
-router.post('/', upload.single('file'), (req, res) => {
+router.post('/', authenticate, upload.single('file'), (req, res) => {
   if (!req.file) return res.status(400).json({ error: 'File is required' });
   db.run('INSERT INTO media(file_name) VALUES(?)', [req.file.filename], function(err) {
     if (err) return res.status(500).json({ error: err.message });

--- a/routes/messages.js
+++ b/routes/messages.js
@@ -1,6 +1,7 @@
 const express = require('express');
 const router = express.Router();
 const { db } = require('../db');
+const authenticate = require('../middleware/auth');
 
 // Get all messages
 router.get('/', (req, res) => {
@@ -11,15 +12,19 @@ router.get('/', (req, res) => {
 });
 
 // Create a new message
-router.post('/', (req, res) => {
-  const { sender_id, receiver_id, content } = req.body;
-  if (!sender_id || !receiver_id || !content) {
-    return res.status(400).json({ error: 'sender_id, receiver_id and content are required' });
+router.post('/', authenticate, (req, res) => {
+  const { receiver_id, content } = req.body;
+  if (!receiver_id || !content) {
+    return res.status(400).json({ error: 'receiver_id and content are required' });
   }
-  db.run('INSERT INTO messages(sender_id, receiver_id, content) VALUES(?, ?, ?)', [sender_id, receiver_id, content], function(err) {
-    if (err) return res.status(500).json({ error: err.message });
-    res.json({ id: this.lastID, sender_id, receiver_id, content });
-  });
+  db.run(
+    'INSERT INTO messages(sender_id, receiver_id, content) VALUES(?, ?, ?)',
+    [req.user.id, receiver_id, content],
+    function(err) {
+      if (err) return res.status(500).json({ error: err.message });
+      res.json({ id: this.lastID, sender_id: req.user.id, receiver_id, content });
+    }
+  );
 });
 
 module.exports = router;

--- a/routes/users.js
+++ b/routes/users.js
@@ -1,28 +1,32 @@
 const express = require('express');
 const router = express.Router();
 const { db } = require('../db');
+const authenticate = require('../middleware/auth');
 
 // Get all users
 router.get('/', (req, res) => {
-  db.all('SELECT * FROM users', [], (err, rows) => {
+  db.all('SELECT id, name, username, email, bio, social FROM users', [], (err, rows) => {
     if (err) return res.status(500).json({ error: err.message });
     res.json(rows);
   });
 });
 
-// Create a new user
-router.post('/', (req, res) => {
-  const { name } = req.body;
-  if (!name) return res.status(400).json({ error: 'Name is required' });
-  db.run('INSERT INTO users(name) VALUES(?)', [name], function(err) {
-    if (err) return res.status(500).json({ error: err.message });
-    res.json({ id: this.lastID, name });
-  });
+// Update current user's profile
+router.post('/', authenticate, (req, res) => {
+  const { name, email, bio, social } = req.body;
+  db.run(
+    'UPDATE users SET name = ?, email = ?, bio = ?, social = ? WHERE id = ?',
+    [name, email, bio, social, req.user.id],
+    function(err) {
+      if (err) return res.status(500).json({ error: err.message });
+      res.json({ updated: this.changes });
+    }
+  );
 });
 
 // Get a user by ID
 router.get('/:id', (req, res) => {
-  db.get('SELECT * FROM users WHERE id = ?', [req.params.id], (err, row) => {
+  db.get('SELECT id, name, username, email, bio, social FROM users WHERE id = ?', [req.params.id], (err, row) => {
     if (err) return res.status(500).json({ error: err.message });
     if (!row) return res.status(404).json({ error: 'User not found' });
     res.json(row);


### PR DESCRIPTION
## Summary
- add bcryptjs and jsonwebtoken dependencies
- extend database `users` table with username, password and profile fields
- create `/auth` routes for registration and login
- add JWT authentication middleware
- protect message and media uploads and profile updates
- update demo front-end to handle login and authorized requests
- document new endpoints in README

## Testing
- `npm install`
- `npm start`

------
https://chatgpt.com/codex/tasks/task_e_688589e187d4832da430a86e21b23792