### PR TITLE
Enable foreign keys and expand database schema

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,10 @@ This project is a Node.js Express server using CommonJS modules and SQLite for p
 - Use 2-space indentation in JavaScript files.
 - Stick to CommonJS `require`/`module.exports` syntax.
 - Keep dependencies minimal.
+- Foreign key constraints are enabled via `PRAGMA foreign_keys = ON`.
+
+## Database
+- New tables: `shows`, `merch` and `board_posts`.
 
 ## Contributions
 - Document any new endpoints or significant features in `README.md`.

--- a/README.md
+++ b/README.md
@@ -45,7 +45,18 @@ upload media using the API endpoints described below.
 
 The API uses **SQLite** for data storage. When you start the server for the
 first time it will automatically create a file named `app.db` in the project
-root containing the required tables.
+root containing the required tables. Foreign key support is enabled with
+`PRAGMA foreign_keys = ON` so related records are removed when a parent row is
+deleted.
+
+Current tables include:
+
+- `users` – basic user profiles
+- `messages` – direct messages linked to `users`
+- `media` – uploaded files
+- `shows` – upcoming performances for an artist
+- `merch` – merchandise items for sale
+- `board_posts` – simple message board entries
 
 ## API Endpoints
 

--- a/db.js
+++ b/db.js
@@ -5,6 +5,8 @@ const db = new sqlite3.Database(path.join(__dirname, 'app.db'));
 // Initialize tables
 const init = () => {
   db.serialize(() => {
+    db.run('PRAGMA foreign_keys = ON');
+
     db.run(`CREATE TABLE IF NOT EXISTS users (
       id INTEGER PRIMARY KEY AUTOINCREMENT,
       name TEXT NOT NULL
@@ -15,13 +17,41 @@ const init = () => {
       sender_id INTEGER NOT NULL,
       receiver_id INTEGER NOT NULL,
       content TEXT NOT NULL,
-      created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+      created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+      FOREIGN KEY(sender_id) REFERENCES users(id) ON DELETE CASCADE ON UPDATE CASCADE,
+      FOREIGN KEY(receiver_id) REFERENCES users(id) ON DELETE CASCADE ON UPDATE CASCADE
     )`);
 
     db.run(`CREATE TABLE IF NOT EXISTS media (
       id INTEGER PRIMARY KEY AUTOINCREMENT,
       file_name TEXT NOT NULL,
       uploaded_at DATETIME DEFAULT CURRENT_TIMESTAMP
+    )`);
+
+    db.run(`CREATE TABLE IF NOT EXISTS shows (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      artist_id INTEGER NOT NULL,
+      venue TEXT NOT NULL,
+      date DATETIME NOT NULL,
+      description TEXT,
+      FOREIGN KEY(artist_id) REFERENCES users(id) ON DELETE CASCADE ON UPDATE CASCADE
+    )`);
+
+    db.run(`CREATE TABLE IF NOT EXISTS merch (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      user_id INTEGER NOT NULL,
+      product_name TEXT NOT NULL,
+      price REAL NOT NULL,
+      stock INTEGER DEFAULT 0,
+      FOREIGN KEY(user_id) REFERENCES users(id) ON DELETE CASCADE ON UPDATE CASCADE
+    )`);
+
+    db.run(`CREATE TABLE IF NOT EXISTS board_posts (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      user_id INTEGER NOT NULL,
+      content TEXT NOT NULL,
+      created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+      FOREIGN KEY(user_id) REFERENCES users(id) ON DELETE CASCADE ON UPDATE CASCADE
     )`);
   });
 };


### PR DESCRIPTION
## Summary
- enforce SQLite foreign key constraints
- add tables for shows, merch items and board posts
- document new tables and constraints in README
- capture new development notes in AGENTS.md

## Testing
- `npm start`

------
https://chatgpt.com/codex/tasks/task_e_68858a16d208832d8929d18e5eccb890