### PR TITLE
Enhance media uploads

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,11 @@ This project is a Node.js Express server using CommonJS modules and SQLite for p
 ## Database
 - New tables: `shows`, `merch` and `board_posts`.
 
+## Media uploads
+- Files are stored in the `uploads/` directory.
+- Only JPEG, PNG, MP3 and MP4 files up to 10 MB are accepted.
+- Uploaded files should be scanned with `clamscan` when available.
+
 ## Contributions
 - Document any new endpoints or significant features in `README.md`.
 - Update this `AGENTS.md` with any new development guidelines.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,9 @@ minimal dependencies. Current endpoints include:
 - `POST /users` – update the authenticated user's profile
 - `GET /users/:id` – fetch a user by id
 - `GET /messages` and `POST /messages` – list and send messages (sending requires authentication)
-- `GET /media` and `POST /media` – list and upload media files (upload requires authentication)
+- `GET /media` – list uploaded files
+- `POST /media` – upload a file (requires authentication)
+- `GET /media/:id` – stream or download a specific file
 
 Future additions will cover show listings, merch management and the message
 board. Everything is intentionally straightforward with no ranking algorithms.
@@ -107,8 +109,9 @@ curl -X POST http://localhost:3000/messages \
 
 ### `/media`
 
-- `GET /media` – list uploaded files
+- `GET /media` – list uploaded files with metadata
 - `POST /media` – upload a file using `multipart/form-data` (requires authentication)
+- `GET /media/:id` – stream or download the file by id
 
 Example request to upload a file:
 
@@ -117,3 +120,8 @@ curl -X POST http://localhost:3000/media \
   -H "Authorization: Bearer <TOKEN>" \
   -F file=@path/to/image.png
 ```
+
+Uploaded files are stored in the `uploads` directory and scanned with
+`clamscan` when available. Only JPEG, PNG, MP3 and MP4 files up to 10 MB are
+accepted. The database records the original filename, MIME type, size and the
+user who uploaded each file.

--- a/app.js
+++ b/app.js
@@ -1,6 +1,7 @@
 const express = require('express');
 const bodyParser = require('body-parser');
 const path = require('path');
+const fs = require('fs');
 const { init } = require('./db');
 
 const usersRouter = require('./routes/users');
@@ -13,6 +14,12 @@ const PORT = process.env.PORT || 3000;
 
 app.use(bodyParser.json());
 app.use(express.static(path.join(__dirname, 'public')));
+
+// Ensure uploads directory exists
+const uploadsDir = path.join(__dirname, 'uploads');
+if (!fs.existsSync(uploadsDir)) {
+  fs.mkdirSync(uploadsDir);
+}
 
 // Initialize database
 init();

--- a/db.js
+++ b/db.js
@@ -30,7 +30,12 @@ const init = () => {
     db.run(`CREATE TABLE IF NOT EXISTS media (
       id INTEGER PRIMARY KEY AUTOINCREMENT,
       file_name TEXT NOT NULL,
-      uploaded_at DATETIME DEFAULT CURRENT_TIMESTAMP
+      original_name TEXT,
+      mime_type TEXT,
+      size INTEGER,
+      user_id INTEGER,
+      uploaded_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+      FOREIGN KEY(user_id) REFERENCES users(id) ON DELETE SET NULL ON UPDATE CASCADE
     )`);
 
     db.run(`CREATE TABLE IF NOT EXISTS shows (
@@ -58,6 +63,19 @@ const init = () => {
       created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
       FOREIGN KEY(user_id) REFERENCES users(id) ON DELETE CASCADE ON UPDATE CASCADE
     )`);
+
+    // Ensure media table has all columns when upgrading from older versions
+    db.all('PRAGMA table_info(media)', [], (err, cols) => {
+      if (err) return;
+      const names = cols.map(c => c.name);
+      const add = (name, type) => {
+        if (!names.includes(name)) db.run(`ALTER TABLE media ADD COLUMN ${name} ${type}`);
+      };
+      add('original_name', 'TEXT');
+      add('mime_type', 'TEXT');
+      add('size', 'INTEGER');
+      add('user_id', 'INTEGER');
+    });
   });
 };
 

--- a/routes/media.js
+++ b/routes/media.js
@@ -3,10 +3,33 @@ const router = express.Router();
 const multer = require('multer');
 const path = require('path');
 const fs = require('fs');
+const { exec } = require('child_process');
 const { db } = require('../db');
 const authenticate = require('../middleware/auth');
 
-const upload = multer({ dest: path.join(__dirname, '..', 'uploads') });
+const uploadDir = path.join(__dirname, '..', 'uploads');
+const allowedTypes = ['image/jpeg', 'image/png', 'audio/mpeg', 'video/mp4'];
+
+const storage = multer.diskStorage({
+  destination: uploadDir,
+  filename: (req, file, cb) => {
+    const unique = Date.now() + '-' + Math.round(Math.random() * 1e9);
+    const sanitized = file.originalname.replace(/[^a-zA-Z0-9._-]/g, '_');
+    cb(null, unique + path.extname(sanitized));
+  }
+});
+
+const upload = multer({
+  storage,
+  limits: { fileSize: 10 * 1024 * 1024 },
+  fileFilter: (req, file, cb) => {
+    if (allowedTypes.includes(file.mimetype)) {
+      cb(null, true);
+    } else {
+      cb(new Error('Invalid MIME type'));
+    }
+  }
+});
 
 // List uploaded files
 router.get('/', (req, res) => {
@@ -19,9 +42,60 @@ router.get('/', (req, res) => {
 // Upload a new file
 router.post('/', authenticate, upload.single('file'), (req, res) => {
   if (!req.file) return res.status(400).json({ error: 'File is required' });
-  db.run('INSERT INTO media(file_name) VALUES(?)', [req.file.filename], function(err) {
+
+  const filePath = path.join(uploadDir, req.file.filename);
+  // Virus scan using clamscan if available
+  exec(`clamscan ${filePath}`, (err, stdout) => {
+    if (err && err.code !== 1 && err.code !== 2) return res.status(500).json({ error: 'Virus scan failed' });
+    if (stdout && stdout.includes('FOUND')) {
+      fs.unlinkSync(filePath);
+      return res.status(400).json({ error: 'Infected file' });
+    }
+
+    db.run(
+      `INSERT INTO media(file_name, original_name, mime_type, size, user_id) VALUES(?,?,?,?,?)`,
+      [req.file.filename, req.file.originalname, req.file.mimetype, req.file.size, req.user.id],
+      function(err2) {
+        if (err2) return res.status(500).json({ error: err2.message });
+        res.json({ id: this.lastID, file: req.file.filename });
+      }
+    );
+  });
+});
+
+// Stream or download a file by id
+router.get('/:id', (req, res) => {
+  db.get('SELECT file_name, mime_type FROM media WHERE id = ?', [req.params.id], (err, row) => {
     if (err) return res.status(500).json({ error: err.message });
-    res.json({ id: this.lastID, file: req.file.filename });
+    if (!row) return res.status(404).json({ error: 'Not found' });
+
+    const filePath = path.join(uploadDir, path.basename(row.file_name));
+    if (!fs.existsSync(filePath)) return res.status(404).json({ error: 'File missing' });
+
+    const stat = fs.statSync(filePath);
+    const range = req.headers.range;
+    const mime = row.mime_type || 'application/octet-stream';
+
+    if (range) {
+      const parts = range.replace(/bytes=/, '').split('-');
+      const start = parseInt(parts[0], 10);
+      const end = parts[1] ? parseInt(parts[1], 10) : stat.size - 1;
+      const chunkSize = end - start + 1;
+      const stream = fs.createReadStream(filePath, { start, end });
+      res.writeHead(206, {
+        'Content-Range': `bytes ${start}-${end}/${stat.size}`,
+        'Accept-Ranges': 'bytes',
+        'Content-Length': chunkSize,
+        'Content-Type': mime
+      });
+      stream.pipe(res);
+    } else {
+      res.writeHead(200, {
+        'Content-Length': stat.size,
+        'Content-Type': mime
+      });
+      fs.createReadStream(filePath).pipe(res);
+    }
   });
 });
 


### PR DESCRIPTION
## Summary
- store more information about each media file (original name, size, MIME type, uploader)
- ensure uploads directory exists at startup
- update database init for new media columns and migrations
- harden upload logic with type/size checks, filename sanitizing and optional clamscan
- add endpoint for streaming or downloading media
- document new endpoints and upload security
- update guidelines about media uploads

## Testing
- `npm install`
- `npm start`

------
https://chatgpt.com/codex/tasks/task_e_68858c2223cc832da54dd9bd70e78bbf