### PR TITLE
Add artist detail view

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,9 +49,11 @@ Once running, open [http://localhost:3000](http://localhost:3000) to view the
 React interface. All frontend libraries (React, React Router, Tailwind and
 Babel) are included in the repository under `public/vendor` so the site works
 without hitting external CDNs. The UI embraces a retro internet vibe and
-provides pages for signing in, browsing artists, managing your profile,
+provides pages for signing in, browsing artists (with individual artist profiles), managing your profile,
 exchanging messages and viewing uploaded media. Placeholders for the upcoming
 show calendar and merch shop are also included.
+Click an artist on the Artists page to view their profile at `/artists/:id`.
+
 
 ## Database
 

--- a/public/app.js
+++ b/public/app.js
@@ -1,7 +1,7 @@
 // React front-end for Under the Radar
 // Uses React and Tailwind from CDNs. Retro fonts via style.css.
 
-const { BrowserRouter, Routes, Route, Link, useNavigate } = ReactRouterDOM;
+const { BrowserRouter, Routes, Route, Link, useNavigate, useParams } = ReactRouterDOM;
 
 function useToken() {
   const [token, setToken] = React.useState(localStorage.getItem('token') || '');
@@ -127,11 +127,32 @@ function Artists() {
   return (
     <div className="p-4 grid grid-cols-1 md:grid-cols-2 gap-4">
       {users.map(u => (
-        <div key={u.id} className="border p-2 bg-white">
+        <Link key={u.id} to={`/artists/${u.id}`} className="border p-2 bg-white block hover:bg-gray-100">
           <div className="font-bold">{u.name}</div>
           <div className="text-sm">@{u.username}</div>
-        </div>
+        </Link>
       ))}
+    </div>
+  );
+}
+
+function ArtistDetail() {
+  const { id } = useParams();
+  const [user, setUser] = React.useState(null);
+  React.useEffect(() => {
+    fetch(`/users/${id}`)
+      .then(r => r.json())
+      .then(setUser);
+  }, [id]);
+  if (!user) return <div className="p-4">Loading...</div>;
+  return (
+    <div className="p-4 space-y-2">
+      <Link className="text-blue-600 underline" to="/artists">Back to artists</Link>
+      <div className="text-xl font-bold">{user.name}</div>
+      <div className="text-sm mb-2">@{user.username}</div>
+      <div>Email: {user.email || 'N/A'}</div>
+      <div>Bio: {user.bio || 'N/A'}</div>
+      <div>Social: {user.social || 'N/A'}</div>
     </div>
   );
 }
@@ -235,6 +256,7 @@ function App() {
           <Route path="/signin" element={<SignIn auth={auth} />} />
           <Route path="/profile" element={<Profile auth={auth} />} />
           <Route path="/artists" element={<Artists />} />
+          <Route path="/artists/:id" element={<ArtistDetail />} />
           <Route path="/messages" element={<Messages auth={auth} />} />
           <Route path="/media" element={<Media auth={auth} />} />
           <Route path="/shows" element={<Placeholder text="Show calendar" />} />


### PR DESCRIPTION
## Summary
- link artist cards to new profile pages
- add `<ArtistDetail>` component
- document artist profile navigation in README

## Testing
- `npm install`
- `npm start` *(then Ctrl-C)*

------
https://chatgpt.com/codex/tasks/task_e_6885b0192fb0832d871f8be0837ee1d8