### PR TITLE
Add Playwright tests and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,19 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: npm install
+      - run: npm start & sleep 5 && kill $! || true
+      - run: npm test

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 app.db
 uploads/
+test-results/

--- a/README.md
+++ b/README.md
@@ -141,3 +141,7 @@ All incoming requests now go through `express-validator` checks. For example,
 IDs must be integers and required fields like usernames may not be empty.
 Any validation issues or other errors are caught by a centralized middleware
 that logs the problem and returns a JSON response with a clear message.
+
+## Testing
+
+Run `npm test` to execute the Playwright unit and integration tests. The tests start the server using an in-memory SQLite database.

--- a/app.js
+++ b/app.js
@@ -36,6 +36,11 @@ app.get('/', (req, res) => {
 
 app.use(errorHandler);
 
-app.listen(PORT, () => {
-  console.log(`Server is running on port ${PORT}`);
-});
+
+if (require.main === module) {
+  app.listen(PORT, () => {
+    console.log(`Server is running on port ${PORT}`);
+  });
+}
+
+module.exports = app;

--- a/db.js
+++ b/db.js
@@ -1,6 +1,7 @@
 const sqlite3 = require('sqlite3').verbose();
 const path = require('path');
-const db = new sqlite3.Database(path.join(__dirname, 'app.db'));
+const dbFile = process.env.DB_FILE || path.join(__dirname, 'app.db');
+const db = new sqlite3.Database(dbFile);
 
 // Initialize tables
 const init = () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,9 @@
         "jsonwebtoken": "^9.0.2",
         "multer": "^2.0.2",
         "sqlite3": "^5.1.7"
+      },
+      "devDependencies": {
+        "@playwright/test": "^1.54.1"
       }
     },
     "node_modules/@gar/promisify": {
@@ -62,6 +65,22 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.54.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.54.1.tgz",
+      "integrity": "sha512-FS8hQ12acieG2dYSksmLOF7BNxnVf2afRJdCuM1eMSxj6QTSE6G4InGF7oApGgDb65MX7AwMVlIkpru0yZA4Xw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.54.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@tootallnate/once": {
@@ -802,6 +821,21 @@
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
       "license": "ISC",
       "optional": true
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
     },
     "node_modules/function-bind": {
       "version": "1.1.2",
@@ -1744,6 +1778,38 @@
       "license": "MIT",
       "engines": {
         "node": ">=16"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.54.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.54.1.tgz",
+      "integrity": "sha512-peWpSwIBmSLi6aW2auvrUtf2DqY16YYcCMO8rTVx486jKmDTJg7UAhyrraP98GB8BoPURZP8+nxO7TSd4cPr5g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.54.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.54.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.54.1.tgz",
+      "integrity": "sha512-Nbjs2zjj0htNhzgiy5wu+3w09YetDx5pkrpI/kZotDlDUaYk0HVA5xrBVPdow4SAUIlhgKcJeJg4GRKW6xHusA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/prebuild-install": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "app.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "playwright test",
     "start": "node app.js"
   },
   "keywords": [],
@@ -12,12 +12,15 @@
   "license": "ISC",
   "type": "commonjs",
   "dependencies": {
+    "bcryptjs": "^2.4.3",
     "body-parser": "^2.2.0",
     "express": "^5.1.0",
-    "multer": "^2.0.2",
-    "sqlite3": "^5.1.7",
-    "bcryptjs": "^2.4.3",
+    "express-validator": "^7.0.1",
     "jsonwebtoken": "^9.0.2",
-    "express-validator": "^7.0.1"
+    "multer": "^2.0.2",
+    "sqlite3": "^5.1.7"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.54.1"
   }
 }

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  testDir: './tests'
+};

--- a/tests/integration/api.test.js
+++ b/tests/integration/api.test.js
@@ -1,0 +1,87 @@
+const http = require('http');
+const { request, test, expect } = require('@playwright/test');
+
+let server;
+let context;
+let baseURL;
+
+// start server with in-memory DB
+
+test.beforeAll(async () => {
+  process.env.DB_FILE = ':memory:';
+  const fs = require('fs');
+  const path = require('path');
+  const bin = path.join(__dirname, 'bin');
+  fs.mkdirSync(bin, { recursive: true });
+  const fake = path.join(bin, 'clamscan');
+  fs.writeFileSync(fake, '#!/bin/sh\nexit 0');
+  fs.chmodSync(fake, 0o755);
+  process.env.PATH = `${bin}:${process.env.PATH}`;
+
+  const app = require('../../app');
+  server = http.createServer(app);
+  await new Promise(resolve => server.listen(0, resolve));
+  baseURL = `http://localhost:${server.address().port}`;
+  context = await request.newContext({ baseURL });
+});
+
+test.afterAll(async () => {
+  await context.dispose();
+  server.close();
+});
+
+test('registration and login', async () => {
+  const res = await context.post('/auth/register', {
+    data: { name: 'Alice', username: 'alice', password: 'pass' }
+  });
+  expect(res.ok()).toBeTruthy();
+  const { token } = await res.json();
+  expect(token).toBeTruthy();
+
+  const login = await context.post('/auth/login', {
+    data: { username: 'alice', password: 'pass' }
+  });
+  expect(login.ok()).toBeTruthy();
+  const body = await login.json();
+  expect(body.token).toBeTruthy();
+});
+
+test('messaging and media upload', async () => {
+  // create two users
+  const u1 = await context.post('/auth/register', {
+    data: { name: 'Bob', username: 'bob', password: 'pw' }
+  });
+  const { token: t1 } = await u1.json();
+
+  const u2 = await context.post('/auth/register', {
+    data: { name: 'Carol', username: 'carol', password: 'pw' }
+  });
+  const { token: t2, id: id2 } = await u2.json();
+
+  // send message from Bob to Carol
+  const msg = await context.post('/messages', {
+    headers: { Authorization: `Bearer ${t1}` },
+    data: { receiver_id: id2, content: 'Hello' }
+  });
+  expect(msg.ok()).toBeTruthy();
+  const mbody = await msg.json();
+  expect(mbody.content).toBe('Hello');
+
+  // upload a file as Carol
+  const fs = require('fs');
+  const path = require('path');
+  const tmpPath = path.join(__dirname, 'test.png');
+  fs.writeFileSync(tmpPath, Buffer.from([0xff, 0xd8, 0xff]));
+  const upload = await context.post('/media', {
+    headers: {
+      Authorization: `Bearer ${t2}`
+    },
+    multipart: {
+      file: fs.createReadStream(tmpPath)
+    }
+  });
+  fs.unlinkSync(tmpPath);
+  expect(upload.ok()).toBeTruthy();
+  const media = await upload.json();
+  expect(media.id).toBeGreaterThan(0);
+});

--- a/tests/unit/auth.test.js
+++ b/tests/unit/auth.test.js
@@ -1,0 +1,33 @@
+const { test, expect } = require('@playwright/test');
+const auth = require('../../middleware/auth');
+const jwt = require('jsonwebtoken');
+
+function createRes() {
+  return {
+    statusCode: null,
+    body: null,
+    status(code) { this.statusCode = code; return this; },
+    json(data) { this.body = data; return this; }
+  };
+}
+
+test('missing token returns 401', () => {
+  const req = { headers: {} };
+  const res = createRes();
+  let called = false;
+  auth(req, res, () => { called = true; });
+  expect(res.statusCode).toBe(401);
+  expect(res.body.error).toBe('Token required');
+  expect(called).toBe(false);
+});
+
+test('valid token calls next', () => {
+  const token = jwt.sign({ id: 1 }, 'secret');
+  const req = { headers: { authorization: `Bearer ${token}` } };
+  const res = createRes();
+  let called = false;
+  auth(req, res, () => { called = true; });
+  expect(res.statusCode).toBe(null);
+  expect(called).toBe(true);
+  expect(req.user.id).toBe(1);
+});


### PR DESCRIPTION
## Summary
- allow db file override and export Express app
- add unit and integration tests using Playwright
- document running tests
- update npm scripts and add dev dependency for Playwright
- add GitHub Actions workflow

## Testing
- `npm start >/tmp/server.log && tail -n 5 /tmp/server.log`
- `npm test >/tmp/test.log && tail -n 20 /tmp/test.log`


------
https://chatgpt.com/codex/tasks/task_e_6885c297c28c832db23e52ac51458316