### PR TITLE
Add logging and monitoring

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,7 @@ This project is a Node.js Express server using CommonJS modules and SQLite for p
 - Use 2-space indentation in JavaScript files.
 - Stick to CommonJS `require`/`module.exports` syntax.
 - Keep dependencies minimal.
+- Use **Pino** for structured logging; all requests should include a request ID.
 - Foreign key constraints are enabled via `PRAGMA foreign_keys = ON`.
 
 ## Database

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ artists with a simple place to:
 - Participate in a message board without algorithmic feeds
 
 The backend is built with Node.js, Express and SQLite using CommonJS modules and
-minimal dependencies. Current endpoints include:
+minimal dependencies. Structured logs are produced with **Pino**. Current endpoints include:
 
 - `POST /auth/register` – create an account
 - `POST /auth/login` – obtain a JWT
@@ -53,6 +53,12 @@ provides pages for signing in, browsing artists (with individual artist profiles
 exchanging messages and viewing uploaded media. Placeholders for the upcoming
 show calendar and merch shop are also included.
 Click an artist on the Artists page to view their profile at `/artists/:id`.
+
+## Logging and Monitoring
+
+All requests are logged in JSON format using **Pino** along with a unique request ID.
+The `/metrics` endpoint exposes basic statistics like total requests, errors and
+average response time.
 
 
 ## Database
@@ -146,6 +152,11 @@ user who uploaded each file.
 - `GET /merch` – list all merch items
 - `GET /merch/user/:id` – merch for a specific user
 - `POST /merch` – create a merch item (requires authentication)
+
+### Misc
+
+- `GET /health` – simple health check returning `{ "status": "ok" }`
+- `GET /metrics` – basic metrics including total requests, errors and average response time
 
 ## Validation and Error Handling
 

--- a/app.js
+++ b/app.js
@@ -3,6 +3,9 @@ const bodyParser = require('body-parser');
 const path = require('path');
 const fs = require('fs');
 const { init } = require('./db');
+const logger = require('./logger');
+const requestLogger = require('./middleware/logger');
+const metrics = require('./metrics');
 
 const usersRouter = require('./routes/users');
 const messagesRouter = require('./routes/messages');
@@ -16,6 +19,7 @@ const app = express();
 const PORT = process.env.PORT || 3000;
 
 app.use(bodyParser.json());
+app.use(requestLogger);
 app.use(express.static(path.join(__dirname, 'public')));
 
 // Ensure uploads directory exists
@@ -34,6 +38,14 @@ app.use('/auth', authRouter);
 app.use('/shows', showsRouter);
 app.use('/merch', merchRouter);
 
+app.get('/health', (req, res) => {
+  res.json({ status: 'ok' });
+});
+
+app.get('/metrics', (req, res) => {
+  res.json(metrics.getMetrics());
+});
+
 app.get('/', (req, res) => {
   res.sendFile(path.join(__dirname, 'public', 'index.html'));
 });
@@ -43,7 +55,7 @@ app.use(errorHandler);
 
 if (require.main === module) {
   app.listen(PORT, () => {
-    console.log(`Server is running on port ${PORT}`);
+    logger.info(`Server is running on port ${PORT}`);
   });
 }
 

--- a/logger.js
+++ b/logger.js
@@ -1,0 +1,3 @@
+const pino = require('pino');
+const logger = pino({ level: process.env.LOG_LEVEL || 'info' });
+module.exports = logger;

--- a/metrics.js
+++ b/metrics.js
@@ -1,0 +1,35 @@
+const metrics = {
+  totalRequests: 0,
+  totalErrors: 0,
+  totalResponseTime: 0
+};
+
+function recordRequest() {
+  metrics.totalRequests += 1;
+}
+
+function recordResponseTime(ms) {
+  metrics.totalResponseTime += ms;
+}
+
+function recordError() {
+  metrics.totalErrors += 1;
+}
+
+function getMetrics() {
+  const avg = metrics.totalRequests
+    ? metrics.totalResponseTime / metrics.totalRequests
+    : 0;
+  return {
+    totalRequests: metrics.totalRequests,
+    totalErrors: metrics.totalErrors,
+    avgResponseTime: Number(avg.toFixed(2))
+  };
+}
+
+module.exports = {
+  recordRequest,
+  recordResponseTime,
+  recordError,
+  getMetrics
+};

--- a/middleware/error.js
+++ b/middleware/error.js
@@ -1,5 +1,9 @@
+const logger = require('../logger');
+const metrics = require('../metrics');
+
 module.exports = (err, req, res, next) => {
-  console.error(err);
+  logger.error({ err, reqId: req.id });
+  metrics.recordError();
   const status = err.status || 500;
   const message = err.message || 'Internal Server Error';
   const response = { error: message };

--- a/middleware/logger.js
+++ b/middleware/logger.js
@@ -1,0 +1,21 @@
+const crypto = require('crypto');
+const logger = require('../logger');
+const metrics = require('../metrics');
+
+module.exports = (req, res, next) => {
+  const start = process.hrtime.bigint();
+  req.id = crypto.randomBytes(6).toString('hex');
+  metrics.recordRequest();
+  res.on('finish', () => {
+    const dur = Number(process.hrtime.bigint() - start) / 1e6;
+    metrics.recordResponseTime(dur);
+    logger.info({
+      reqId: req.id,
+      method: req.method,
+      url: req.originalUrl,
+      status: res.statusCode,
+      duration: dur.toFixed(2)
+    });
+  });
+  next();
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "express-validator": "^7.0.1",
         "jsonwebtoken": "^9.0.2",
         "multer": "^2.0.2",
+        "pino": "^9.7.0",
         "sqlite3": "^5.1.7"
       },
       "devDependencies": {
@@ -189,6 +190,15 @@
       },
       "engines": {
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/atomic-sleep": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
+      "integrity": "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/balanced-match": {
@@ -754,6 +764,15 @@
       },
       "engines": {
         "node": ">= 8.0.0"
+      }
+    },
+    "node_modules/fast-redact": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-3.5.0.tgz",
+      "integrity": "sha512-dwsoQlS7h9hMeYUq1W++23NDcBLV4KqONnITDV9DjfS3q1SgDGVrBdvvTLUotWtPSD7asWDV9/CmsZPy8Hf70A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/file-uri-to-path": {
@@ -1715,6 +1734,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/on-exit-leak-free": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.2.tgz",
+      "integrity": "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/on-finished": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
@@ -1780,6 +1808,43 @@
         "node": ">=16"
       }
     },
+    "node_modules/pino": {
+      "version": "9.7.0",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-9.7.0.tgz",
+      "integrity": "sha512-vnMCM6xZTb1WDmLvtG2lE/2p+t9hDEIvTWJsu6FejkE62vB7gDhvzrpFR4Cw2to+9JNQxVnkAKVPA1KPB98vWg==",
+      "license": "MIT",
+      "dependencies": {
+        "atomic-sleep": "^1.0.0",
+        "fast-redact": "^3.1.1",
+        "on-exit-leak-free": "^2.1.0",
+        "pino-abstract-transport": "^2.0.0",
+        "pino-std-serializers": "^7.0.0",
+        "process-warning": "^5.0.0",
+        "quick-format-unescaped": "^4.0.3",
+        "real-require": "^0.2.0",
+        "safe-stable-stringify": "^2.3.1",
+        "sonic-boom": "^4.0.1",
+        "thread-stream": "^3.0.0"
+      },
+      "bin": {
+        "pino": "bin.js"
+      }
+    },
+    "node_modules/pino-abstract-transport": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-2.0.0.tgz",
+      "integrity": "sha512-F63x5tizV6WCh4R6RHyi2Ml+M70DNRXt/+HANowMflpgGFMAym/VKm6G7ZOQRjqN7XbGxK1Lg9t6ZrtzOaivMw==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.0.0"
+      }
+    },
+    "node_modules/pino-std-serializers": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-7.0.0.tgz",
+      "integrity": "sha512-e906FRY0+tV27iq4juKzSYPbUj2do2X2JX4EzSca1631EB2QJQUqGbDuERal7LCtOpxl6x3+nvo9NPZcmjkiFA==",
+      "license": "MIT"
+    },
     "node_modules/playwright": {
       "version": "1.54.1",
       "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.54.1.tgz",
@@ -1837,6 +1902,22 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/process-warning": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-5.0.0.tgz",
+      "integrity": "sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/promise-inflight": {
       "version": "1.0.1",
@@ -1897,6 +1978,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/quick-format-unescaped": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
+      "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==",
+      "license": "MIT"
+    },
     "node_modules/range-parser": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
@@ -1948,6 +2035,15 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/real-require": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.2.0.tgz",
+      "integrity": "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12.13.0"
       }
     },
     "node_modules/retry": {
@@ -2012,6 +2108,15 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/safe-stable-stringify": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
+      "integrity": "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
@@ -2246,6 +2351,24 @@
         "node": ">= 10"
       }
     },
+    "node_modules/sonic-boom": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-4.2.0.tgz",
+      "integrity": "sha512-INb7TM37/mAcsGmc9hyyI6+QR3rR1zVRu36B0NeGXKnOOLiZOfER5SA+N7X7k3yUYRzLWafduTDvJAfDswwEww==",
+      "license": "MIT",
+      "dependencies": {
+        "atomic-sleep": "^1.0.0"
+      }
+    },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
+      }
+    },
     "node_modules/sprintf-js": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
@@ -2423,6 +2546,15 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/thread-stream": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-3.1.0.tgz",
+      "integrity": "sha512-OqyPZ9u96VohAyMfJykzmivOrY2wfMSf3C5TtFJVgN+Hm6aj+voFhlK+kZEIv2FBh1X6Xp3DlnCOfEQ3B2J86A==",
+      "license": "MIT",
+      "dependencies": {
+        "real-require": "^0.2.0"
       }
     },
     "node_modules/toidentifier": {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "express-validator": "^7.0.1",
     "jsonwebtoken": "^9.0.2",
     "multer": "^2.0.2",
+    "pino": "^9.7.0",
     "sqlite3": "^5.1.7"
   },
   "devDependencies": {

--- a/tests/integration/api.test.js
+++ b/tests/integration/api.test.js
@@ -85,3 +85,10 @@ test('messaging and media upload', async () => {
   const media = await upload.json();
   expect(media.id).toBeGreaterThan(0);
 });
+
+test('health check works', async () => {
+  const res = await context.get('/health');
+  expect(res.ok()).toBeTruthy();
+  const body = await res.json();
+  expect(body.status).toBe('ok');
+});


### PR DESCRIPTION
## Summary
- integrate Pino logger and add middleware for request logging
- collect metrics for requests, errors and response times
- expose new `/health` and `/metrics` endpoints
- document logging and monitoring features
- update agent guidelines
- test new health endpoint

## Testing
- `npm test`
- `npm start`

------
https://chatgpt.com/codex/tasks/task_e_6885d166783c832d984d5ec4289a8ccd