### PR TITLE
Add board feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ artists with a simple place to:
 - Post show dates
 - Sell merchandise directly
 - Participate in a message board without algorithmic feeds
+- Post updates to a shared bulletin board
 
 The backend is built with Node.js, Express and SQLite using CommonJS modules and
 minimal dependencies. Structured logs are produced with **Pino**. Current endpoints include:
@@ -152,6 +153,12 @@ user who uploaded each file.
 - `GET /merch` – list all merch items
 - `GET /merch/user/:id` – merch for a specific user
 - `POST /merch` – create a merch item (requires authentication)
+
+### `/board`
+
+- `GET /board` – list all board posts
+- `GET /board/user/:id` – posts by a specific user
+- `POST /board` – create a new board post (requires authentication)
 
 ### Misc
 

--- a/app.js
+++ b/app.js
@@ -13,6 +13,7 @@ const mediaRouter = require('./routes/media');
 const authRouter = require('./routes/auth');
 const showsRouter = require('./routes/shows');
 const merchRouter = require('./routes/merch');
+const boardRouter = require('./routes/board');
 const errorHandler = require('./middleware/error');
 
 const app = express();
@@ -37,6 +38,7 @@ app.use('/media', mediaRouter);
 app.use('/auth', authRouter);
 app.use('/shows', showsRouter);
 app.use('/merch', merchRouter);
+app.use('/board', boardRouter);
 
 app.get('/health', (req, res) => {
   res.json({ status: 'ok' });

--- a/public/app.js
+++ b/public/app.js
@@ -28,6 +28,7 @@ function Nav({ auth }) {
       <Link className="hover:underline" to="/artists">Artists</Link>
       <Link className="hover:underline" to="/media">Media</Link>
       <Link className="hover:underline" to="/messages">Messages</Link>
+      <Link className="hover:underline" to="/board">Board</Link>
       <Link className="hover:underline" to="/shows">Shows</Link>
       <Link className="hover:underline" to="/merch">Merch</Link>
       {auth.token ? (
@@ -339,6 +340,64 @@ function ShowsSection({ userId }) {
   );
 }
 
+function Board({ auth }) {
+  const [posts, setPosts] = React.useState([]);
+  const [content, setContent] = React.useState('');
+
+  const load = () => {
+    fetch('/board')
+      .then(r => r.json())
+      .then(setPosts);
+  };
+
+  React.useEffect(load, []);
+
+  const submit = () => {
+    if (!content || !auth.token) return alert('Sign in and enter content');
+    fetch('/board', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${auth.token}`
+      },
+      body: JSON.stringify({ content })
+    })
+      .then(r => r.json())
+      .then(() => {
+        setContent('');
+        load();
+      });
+  };
+
+  return (
+    <div className="p-4 space-y-2">
+      {auth.token && (
+        <div>
+          <input
+            className="border p-1 mr-2"
+            placeholder="New post"
+            value={content}
+            onChange={e => setContent(e.target.value)}
+          />
+          <button className="bg-blue-600 text-white px-2 py-1" onClick={submit}>
+            Post
+          </button>
+        </div>
+      )}
+      <div className="space-y-2">
+        {posts.map(p => (
+          <div key={p.id} className="border p-2 bg-white">
+            <div className="text-sm text-gray-600">
+              {p.username} - {new Date(p.created_at).toLocaleString()}
+            </div>
+            <div>{p.content}</div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
 function Placeholder({ text }) {
   return <div className="p-4">{text} coming soon!</div>;
 }
@@ -357,6 +416,7 @@ function App() {
           <Route path="/artists/:id" element={<ArtistDetail />} />
           <Route path="/messages" element={<Messages auth={auth} />} />
           <Route path="/media" element={<Media auth={auth} />} />
+          <Route path="/board" element={<Board auth={auth} />} />
           <Route path="/shows" element={<Placeholder text="Show calendar" />} />
           <Route path="/merch" element={<Placeholder text="Merch shop" />} />
         </Routes>

--- a/routes/board.js
+++ b/routes/board.js
@@ -1,0 +1,51 @@
+const express = require('express');
+const router = express.Router();
+const { db } = require('../db');
+const authenticate = require('../middleware/auth');
+const { body, param } = require('express-validator');
+const validate = require('../middleware/validate');
+
+// List all board posts
+router.get('/', (req, res, next) => {
+  db.all(
+    'SELECT board_posts.*, users.username FROM board_posts JOIN users ON board_posts.user_id = users.id ORDER BY created_at DESC',
+    [],
+    (err, rows) => {
+      if (err) return next(err);
+      res.json(rows);
+    }
+  );
+});
+
+// Get posts by user
+router.get('/user/:id', param('id').isInt(), validate, (req, res, next) => {
+  db.all(
+    'SELECT board_posts.*, users.username FROM board_posts JOIN users ON board_posts.user_id = users.id WHERE user_id = ? ORDER BY created_at DESC',
+    [req.params.id],
+    (err, rows) => {
+      if (err) return next(err);
+      res.json(rows);
+    }
+  );
+});
+
+// Create a board post
+router.post(
+  '/',
+  authenticate,
+  body('content').trim().notEmpty(),
+  validate,
+  (req, res, next) => {
+    const { content } = req.body;
+    db.run(
+      'INSERT INTO board_posts(user_id, content) VALUES(?, ?)',
+      [req.user.id, content],
+      function (err) {
+        if (err) return next(err);
+        res.json({ id: this.lastID, user_id: req.user.id, content });
+      }
+    );
+  }
+);
+
+module.exports = router;

--- a/tests/integration/api.test.js
+++ b/tests/integration/api.test.js
@@ -86,6 +86,22 @@ test('messaging and media upload', async () => {
   expect(media.id).toBeGreaterThan(0);
 });
 
+test('board post creation', async () => {
+  const reg = await context.post('/auth/register', {
+    data: { name: 'Dana', username: 'dana', password: 'pw' }
+  });
+  const { token } = await reg.json();
+  const post = await context.post('/board', {
+    headers: { Authorization: `Bearer ${token}` },
+    data: { content: 'Hello board' }
+  });
+  expect(post.ok()).toBeTruthy();
+  const all = await context.get('/board');
+  expect(all.ok()).toBeTruthy();
+  const items = await all.json();
+  expect(items.find(p => p.content === 'Hello board')).toBeTruthy();
+});
+
 test('health check works', async () => {
   const res = await context.get('/health');
   expect(res.ok()).toBeTruthy();


### PR DESCRIPTION
## Summary
- add board routes for posting updates
- document board endpoints in README
- expose board router in Express app
- add board page to frontend React app
- test board post creation

## Testing
- `npm start`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688649cd1a7c832d8b4b3767738c9673