### PR TITLE
Fix avatar upload error when clamscan missing

### DIFF
--- a/routes/media.js
+++ b/routes/media.js
@@ -52,7 +52,11 @@ router.post('/', authenticate, upload.single('file'), (req, res, next) => {
   const filePath = path.join(uploadDir, req.file.filename);
   // Virus scan using clamscan if available
   exec(`clamscan ${filePath}`, (err, stdout) => {
-    if (err && err.code !== 1 && err.code !== 2) return next(new Error('Virus scan failed'));
+    if (err && err.code === 127) {
+      // clamscan not installed, skip scanning
+    } else if (err && err.code !== 1 && err.code !== 2) {
+      return next(new Error('Virus scan failed'));
+    }
     if (stdout && stdout.includes('FOUND')) {
       fs.unlinkSync(filePath);
       const infected = new Error('Infected file');

--- a/routes/users.js
+++ b/routes/users.js
@@ -67,7 +67,11 @@ router.post('/avatar', authenticate, upload.single('avatar'), (req, res, next) =
   }
   const filePath = path.join(uploadDir, req.file.filename);
   exec(`clamscan ${filePath}`, (err, stdout) => {
-    if (err && err.code !== 1 && err.code !== 2) return next(new Error('Virus scan failed'));
+    if (err && err.code === 127) {
+      // clamscan not installed, skip scanning
+    } else if (err && err.code !== 1 && err.code !== 2) {
+      return next(new Error('Virus scan failed'));
+    }
     if (stdout && stdout.includes('FOUND')) {
       fs.unlinkSync(filePath);
       const infected = new Error('Infected file');


### PR DESCRIPTION
## Summary
- skip virus scanning when `clamscan` isn't installed
- avoid failing profile picture and media uploads when the binary is missing

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688669f62ff0832dbf0771103849ffdc