### PR TITLE
Add user search functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ minimal dependencies. Structured logs are produced with **Pino**. Current endpoi
 
 - `POST /auth/register` – create an account (set `is_artist` to `true` for artist profiles)
 - `POST /auth/login` – obtain a JWT
-- `GET /users` – list user profiles (`?type=artist` or `?type=user` to filter)
+- `GET /users` – list user profiles (`?type=artist` or `?type=user` to filter, `?q=` to search, `?letter=` to filter by first letter)
 - `POST /users` – update the authenticated user's profile
 - `GET /users/:id` – fetch a user by id
 - `POST /users/avatar` – upload a profile picture (requires authentication)
@@ -128,7 +128,7 @@ curl -X POST http://localhost:3000/auth/login \
 
 ### `/users`
 
-- `GET /users` – list users (`?type=artist` or `?type=user` to filter)
+- `GET /users` – list users (`?type=artist` or `?type=user` to filter, `?q=` to search, `?letter=` to filter by first letter)
 - `POST /users` – update the authenticated user's profile
 - `GET /users/:id` – fetch a user by id
 - `POST /users/avatar` – upload or update your profile picture

--- a/openapi.json
+++ b/openapi.json
@@ -101,6 +101,18 @@
             "in": "query",
             "schema": { "type": "string", "enum": ["artist", "user"] },
             "description": "Filter by profile type"
+          },
+          {
+            "name": "q",
+            "in": "query",
+            "schema": { "type": "string" },
+            "description": "Search name or username"
+          },
+          {
+            "name": "letter",
+            "in": "query",
+            "schema": { "type": "string", "minLength": 1, "maxLength": 1 },
+            "description": "Filter by starting letter"
           }
         ],
         "responses": {

--- a/public/app.js
+++ b/public/app.js
@@ -243,11 +243,17 @@ function EditProfile({ auth }) {
 function Browse({ defaultTab = 'artist' }) {
   const [tab, setTab] = React.useState(defaultTab);
   const [users, setUsers] = React.useState([]);
-  React.useEffect(() => {
-    fetch(`/users?type=${tab}`)
+  const [query, setQuery] = React.useState('');
+  const [letter, setLetter] = React.useState('');
+  const load = () => {
+    let url = `/users?type=${tab}`;
+    if (query) url += `&q=${encodeURIComponent(query)}`;
+    if (letter) url += `&letter=${letter}`;
+    fetch(url)
       .then(r => r.json())
       .then(setUsers);
-  }, [tab]);
+  };
+  React.useEffect(load, [tab, query, letter]);
   const base = tab === 'artist' ? '/artists/' : '/users/';
   return (
     <div className="p-4">
@@ -264,6 +270,32 @@ function Browse({ defaultTab = 'artist' }) {
         >
           Users
         </button>
+      </div>
+      <div className="mb-2">
+        <input
+          className="border p-1 mr-2"
+          placeholder="Search..."
+          value={query}
+          onChange={e => setQuery(e.target.value)}
+        />
+        <button className="border px-2 py-1" onClick={() => setQuery('')}>Clear</button>
+      </div>
+      <div className="mb-4 flex flex-wrap space-x-1">
+        <button
+          className={`px-2 py-1 ${letter === '' ? 'bg-blue-600 text-white' : 'bg-white border'}`}
+          onClick={() => setLetter('')}
+        >
+          All
+        </button>
+        {Array.from({ length: 26 }, (_, i) => String.fromCharCode(65 + i)).map(l => (
+          <button
+            key={l}
+            className={`px-2 py-1 ${letter === l ? 'bg-blue-600 text-white' : 'bg-white border'}`}
+            onClick={() => setLetter(l)}
+          >
+            {l}
+          </button>
+        ))}
       </div>
       <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
         {users.map(u => (

--- a/routes/users.js
+++ b/routes/users.js
@@ -30,14 +30,28 @@ const upload = multer({
 
 // Get all users
 router.get('/', (req, res) => {
-  let sql = 'SELECT id, name, username, email, bio, social, avatar_id, is_artist FROM users';
-  const { type } = req.query;
+  let sql =
+    'SELECT id, name, username, email, bio, social, avatar_id, is_artist FROM users';
+  const params = [];
+  const { type, q, letter } = req.query;
+  const conditions = [];
   if (type === 'artist') {
-    sql += ' WHERE is_artist = 1';
+    conditions.push('is_artist = 1');
   } else if (type === 'user') {
-    sql += ' WHERE is_artist = 0';
+    conditions.push('is_artist = 0');
   }
-  db.all(sql, [], (err, rows) => {
+  if (q) {
+    conditions.push('(name LIKE ? COLLATE NOCASE OR username LIKE ? COLLATE NOCASE)');
+    params.push(`%${q}%`, `%${q}%`);
+  }
+  if (letter) {
+    conditions.push('(name LIKE ? COLLATE NOCASE OR username LIKE ? COLLATE NOCASE)');
+    params.push(`${letter}%`, `${letter}%`);
+  }
+  if (conditions.length) {
+    sql += ' WHERE ' + conditions.join(' AND ');
+  }
+  db.all(sql, params, (err, rows) => {
     if (err) return res.status(500).json({ error: err.message });
     res.json(rows);
   });

--- a/tests/integration/api.test.js
+++ b/tests/integration/api.test.js
@@ -262,3 +262,25 @@ test('user type filtering works', async () => {
   const fanList = await fans.json();
   expect(fanList.every(u => u.is_artist === 0)).toBeTruthy();
 });
+
+test('user search works', async () => {
+  await context.post('/auth/register', {
+    data: { name: 'Alice', username: 'alice123', password: 'pw', is_artist: true }
+  });
+  await context.post('/auth/register', {
+    data: { name: 'Bob', username: 'bobby', password: 'pw', is_artist: false }
+  });
+  await context.post('/auth/register', {
+    data: { name: 'Charlie', username: 'charlie', password: 'pw', is_artist: true }
+  });
+
+  const search = await context.get('/users?q=obb');
+  const searchList = await search.json();
+  expect(searchList.length).toBe(1);
+  expect(searchList[0].username).toBe('bobby');
+
+  const letter = await context.get('/users?letter=C&type=artist');
+  const letterList = await letter.json();
+  expect(letterList.length).toBe(1);
+  expect(letterList[0].username).toBe('charlie');
+});


### PR DESCRIPTION
## Summary
- implement search and letter filters for `/users` API
- document query params in README and OpenAPI spec
- add search interface on browse page
- test search API functionality

## Testing
- `npm start`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68877af66a2c832db892fd224af3f3aa