### PR TITLE
Implement board post expansion and comment editing

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,9 @@ user who uploaded each file.
 - `POST /board/:id/dislike` – dislike a post (requires authentication)
 - `GET /board/:id/comments` – list comments on a post
 - `POST /board/:id/comments` – add a comment (requires authentication)
+- `PUT /board/comments/:id` – edit a comment (requires authentication)
+- `DELETE /board/comments/:id` – delete a comment (requires authentication)
+- `DELETE /board/:id` – delete a board post (requires authentication)
 
 ### Misc
 

--- a/openapi.json
+++ b/openapi.json
@@ -267,6 +267,13 @@
       "get": {"summary": "List comments", "parameters": [{"name": "id", "in": "path", "required": true, "schema": {"type": "integer"}}], "responses": {"200": {"description": "Comments"}}},
       "post": {"summary": "Add comment", "security": [{"BearerAuth": []}], "parameters": [{"name": "id", "in": "path", "required": true, "schema": {"type": "integer"}}], "requestBody": {"required": true, "content": {"application/json": {"schema": {"type": "object", "required": ["content"], "properties": {"content": {"type": "string"}}}}}}, "responses": {"200": {"description": "Created"}}}
     },
+    "/board/comments/{id}": {
+      "put": {"summary": "Edit comment", "security": [{"BearerAuth": []}], "parameters": [{"name": "id", "in": "path", "required": true, "schema": {"type": "integer"}}], "requestBody": {"required": true, "content": {"application/json": {"schema": {"type": "object", "required": ["content"], "properties": {"content": {"type": "string"}}}}}}, "responses": {"200": {"description": "Updated"}}},
+      "delete": {"summary": "Delete comment", "security": [{"BearerAuth": []}], "parameters": [{"name": "id", "in": "path", "required": true, "schema": {"type": "integer"}}], "responses": {"200": {"description": "Deleted"}}}
+    },
+    "/board/{id}": {
+      "delete": {"summary": "Delete post", "security": [{"BearerAuth": []}], "parameters": [{"name": "id", "in": "path", "required": true, "schema": {"type": "integer"}}], "responses": {"200": {"description": "Deleted"}}}
+    },
     "/health": {
       "get": {"summary": "Health check", "responses": {"200": {"description": "OK", "content": {"application/json": {"example": {"status": "ok"}}}}}}
     },


### PR DESCRIPTION
## Summary
- allow deleting board posts and editing/deleting comments
- document new board endpoints in README and OpenAPI
- add frontend controls for editing/deleting board comments and posts
- cover new functionality in integration tests

## Testing
- `npm test`
- `npm start`

------
https://chatgpt.com/codex/tasks/task_e_688783fc4294832d9aceaea7458e6c16