### PR TITLE
Add board post editing support

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,7 @@ user who uploaded each file.
 - `POST /board/:id/dislike` – dislike a post (requires authentication)
 - `GET /board/:id/comments` – list comments on a post
 - `POST /board/:id/comments` – add a comment (requires authentication)
+- `PUT /board/:id` – edit a board post (requires authentication)
 - `PUT /board/comments/:id` – edit a comment (requires authentication)
 - `DELETE /board/comments/:id` – delete a comment (requires authentication)
 - `DELETE /board/:id` – delete a board post (requires authentication)

--- a/openapi.json
+++ b/openapi.json
@@ -272,6 +272,7 @@
       "delete": {"summary": "Delete comment", "security": [{"BearerAuth": []}], "parameters": [{"name": "id", "in": "path", "required": true, "schema": {"type": "integer"}}], "responses": {"200": {"description": "Deleted"}}}
     },
     "/board/{id}": {
+      "put": {"summary": "Edit post", "security": [{"BearerAuth": []}], "parameters": [{"name": "id", "in": "path", "required": true, "schema": {"type": "integer"}}], "requestBody": {"required": true, "content": {"application/json": {"schema": {"type": "object", "required": ["content"], "properties": {"content": {"type": "string"}}}}}}, "responses": {"200": {"description": "Updated"}}},
       "delete": {"summary": "Delete post", "security": [{"BearerAuth": []}], "parameters": [{"name": "id", "in": "path", "required": true, "schema": {"type": "integer"}}], "responses": {"200": {"description": "Deleted"}}}
     },
     "/health": {

--- a/routes/board.js
+++ b/routes/board.js
@@ -107,6 +107,35 @@ router.post(
   }
 );
 
+// Update a board post
+router.put(
+  '/:id',
+  authenticate,
+  param('id').isInt(),
+  body('content').trim().notEmpty().escape(),
+  validate,
+  (req, res, next) => {
+    const { content } = req.body;
+    db.get('SELECT user_id FROM board_posts WHERE id = ?', [req.params.id], (err, row) => {
+      if (err) return next(err);
+      if (!row) {
+        const nf = new Error('Post not found');
+        nf.status = 404;
+        return next(nf);
+      }
+      if (row.user_id !== req.user.id) {
+        const no = new Error('Not allowed');
+        no.status = 403;
+        return next(no);
+      }
+      db.run('UPDATE board_posts SET content = ? WHERE id = ?', [content, req.params.id], err2 => {
+        if (err2) return next(err2);
+        res.json({ success: true });
+      });
+    });
+  }
+);
+
 // Update a comment
 router.put(
   '/comments/:id',

--- a/tests/integration/api.test.js
+++ b/tests/integration/api.test.js
@@ -139,6 +139,26 @@ test('board post interactions', async () => {
   expect(list.find(c => c.content === 'Nice')).toBeTruthy();
 });
 
+test('board post editing', async () => {
+  const reg = await context.post('/auth/register', {
+    data: { name: 'Mia', username: 'mia', password: 'pw' }
+  });
+  const { token } = await reg.json();
+  const created = await context.post('/board', {
+    headers: { Authorization: `Bearer ${token}` },
+    data: { content: 'Original' }
+  });
+  const { id } = await created.json();
+  const edit = await context.put(`/board/${id}`, {
+    headers: { Authorization: `Bearer ${token}` },
+    data: { content: 'Edited' }
+  });
+  expect(edit.ok()).toBeTruthy();
+  const posts = await context.get('/board');
+  const arr = await posts.json();
+  expect(arr.find(p => p.id === id).content).toBe('Edited');
+});
+
 test('comment editing and post deletion', async () => {
   const u1 = await context.post('/auth/register', {
     data: { name: 'Ken', username: 'ken', password: 'pw' }


### PR DESCRIPTION
## Summary
- allow editing of board posts
- document the new endpoint in README and Swagger
- test editing functionality

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6887894684a4832dbea0d69b9452dedc