### PR TITLE
Return 404 for missing user

### DIFF
--- a/routes/users.js
+++ b/routes/users.js
@@ -83,6 +83,7 @@ router.post(
       [req.user.id],
       (err, row) => {
         if (err) return next(err);
+        if (!row) return res.status(404).json({ error: 'User not found' });
         const newVals = {
           name: name !== undefined ? name : row.name,
           email: email !== undefined ? email : row.email,
@@ -158,7 +159,7 @@ router.get(
       [req.params.id],
       (err, row) => {
         if (err) return next(err);
-        if (!row) return next(new Error('User not found'));
+        if (!row) return res.status(404).json({ error: 'User not found' });
         res.json(row);
       }
     );

--- a/tests/integration/api.test.js
+++ b/tests/integration/api.test.js
@@ -531,3 +531,18 @@ test('leaderboard tracks points', async () => {
   expect(fanData.fan_points).toBeGreaterThan(0);
   expect(fanData.artist_points).toBe(0);
 });
+
+test('returns 404 for missing user', async () => {
+  const res = await context.get('/users/9999');
+  expect(res.status()).toBe(404);
+});
+
+test('profile update returns 404 for missing user', async () => {
+  const jwt = require('jsonwebtoken');
+  const token = jwt.sign({ id: 9999, username: 'ghost' }, 'secret');
+  const res = await context.post('/users', {
+    headers: { Authorization: `Bearer ${token}` },
+    data: { name: 'Ghost' }
+  });
+  expect(res.status()).toBe(404);
+});


### PR DESCRIPTION
## Summary
- handle user not found cases in user routes
- add integration tests for missing user responses

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6889325cf5c8832d883a267e872083c2