### PR TITLE
Add catch-all route

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ Babel) are included in the repository under `public/vendor` so the site works
 without hitting external CDNs. The UI embraces a retro internet vibe and
  provides pages for signing in, choosing an Artist or regular User profile during registration, and browsing community profiles via the new `/browse` page which features tabs to switch between artists and users. You can also view your profile and edit it at `/profile/edit`. When signed in, your profile picture appears in the top-right corner of the navigation bar and links back to your profile. Your username is displayed beside the avatar so you know which account is active. Use the "Edit Profile" button on your profile page to update details, pick a color theme or add custom HTML for deeper customization. Placeholders for the upcoming
 show calendar and merch shop are also included.
+Any other route will also load `index.html` so client-side routing works.
 Swagger documentation is available at [http://localhost:3000/docs](http://localhost:3000/docs).
 Click a profile on the Browse page to view details at `/artists/:id` or `/users/:id`.
 

--- a/app.js
+++ b/app.js
@@ -84,6 +84,10 @@ app.get('/', (req, res) => {
   res.sendFile(path.join(__dirname, 'public', 'index.html'));
 });
 
+app.get('/*path', (req, res) =>
+  res.sendFile(path.join(__dirname, 'public', 'index.html'))
+);
+
 app.use(errorHandler);
 
 

--- a/tests/integration/catchall.test.js
+++ b/tests/integration/catchall.test.js
@@ -1,0 +1,27 @@
+const http = require('http');
+const { test, expect, request } = require('@playwright/test');
+
+let server;
+let context;
+let baseURL;
+
+test.beforeAll(async () => {
+  process.env.DB_FILE = ':memory:';
+  const app = require('../../app');
+  server = http.createServer(app);
+  await new Promise(resolve => server.listen(0, resolve));
+  baseURL = `http://localhost:${server.address().port}`;
+  context = await request.newContext({ baseURL });
+});
+
+test.afterAll(async () => {
+  await context.dispose();
+  server.close();
+});
+
+test('unknown routes serve index.html', async () => {
+  const res = await context.get('/some/random/path');
+  expect(res.status()).toBe(200);
+  const text = await res.text();
+  expect(text.startsWith('<!DOCTYPE html>')).toBeTruthy();
+});


### PR DESCRIPTION
## Summary
- serve index.html for unknown routes
- note catch-all routing behavior in README
- test that catch-all route works

## Testing
- `npm start`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688957766a34832db70252e40bcaa5a5