### PR TITLE
Add gradient hero section with sign-in CTA

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -104,11 +104,14 @@ function Nav({ auth, unread }) {
 
 function Home() {
   return (
-    <div className="p-4 space-y-2">
-      <div className="text-xl font-bold">Under the Radar</div>
-      <p>A home for underground musicians to share their art without algorithms.</p>
-      <p>Create a profile, upload your tracks and photos, list shows and sell merch directly to fans.</p>
-    </div>
+    <section className="w-full bg-gradient-to-r from-blue-500 to-purple-600 text-white text-center py-20 hero-section">
+      <h1 className="text-4xl font-bold mb-4 hero-title">Under the Radar</h1>
+      <p className="text-lg mb-2">A home for underground musicians to share their art without algorithms.</p>
+      <p className="mb-6">Create a profile, upload your tracks and photos, list shows and sell merch directly to fans.</p>
+      <Link className="bg-white text-blue-600 px-4 py-2 rounded hover:bg-gray-100" to="/signin">
+        Get Started
+      </Link>
+    </section>
   );
 }
 

--- a/public/style.css
+++ b/public/style.css
@@ -19,3 +19,11 @@ body {
   background-color: #e0f7fa;
   color: #014751;
 }
+
+.hero-section {
+  background-image: radial-gradient(circle at center, rgba(255, 255, 255, 0.15), transparent 70%);
+}
+
+.hero-title {
+  text-shadow: 2px 2px 0 rgba(0, 0, 0, 0.5);
+}


### PR DESCRIPTION
## Summary
- Redesign Home component with a full-width gradient hero, headline, and sign-in button
- Add optional hero CSS for background accent and typography

## Testing
- `npm start`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6894359caf6c832d800621c9fad85a55