### PR TITLE
feat: add database seeding

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,12 @@ Start the server:
 npm start
 ```
 
+Seed demo data manually:
+
+```bash
+npm run seed
+```
+
 Environment variables are loaded from a `.env` file. Set `PORT`, `DB_FILE` and
 `JWT_SECRET` as needed. Optional values include `CORS_ORIGIN` and rate limit
 settings. The server listens on port `3000` if `PORT` is not specified.

--- a/db.js
+++ b/db.js
@@ -4,7 +4,7 @@ const dbFile = process.env.DB_FILE || path.join(__dirname, 'app.db');
 const db = new sqlite3.Database(dbFile);
 
 // Initialize tables
-const init = () => {
+const init = (options = {}) => {
   db.serialize(() => {
     db.run('PRAGMA foreign_keys = ON');
 
@@ -240,12 +240,14 @@ const init = () => {
       }
     });
 
-    db.get('SELECT COUNT(*) AS c FROM users', (err, row) => {
-      if (!err && row.c === 0) {
-        const seed = require('./seed');
-        seed(db);
-      }
-    });
+    if (options.seedDemo !== false) {
+      db.get('SELECT COUNT(*) AS c FROM users', (err, row) => {
+        if (!err && row.c === 0) {
+          const seed = require('./seed');
+          seed(db);
+        }
+      });
+    }
   });
 };
 

--- a/db.js
+++ b/db.js
@@ -239,6 +239,13 @@ const init = () => {
         db.run("INSERT INTO artist_badges(badge_name, description) VALUES('Debut Release','Uploaded first media')");
       }
     });
+
+    db.get('SELECT COUNT(*) AS c FROM users', (err, row) => {
+      if (!err && row.c === 0) {
+        const seed = require('./seed');
+        seed(db);
+      }
+    });
   });
 };
 

--- a/db.js
+++ b/db.js
@@ -162,60 +162,29 @@ const init = (options = {}) => {
       FOREIGN KEY(badge_id) REFERENCES artist_badges(id) ON DELETE CASCADE ON UPDATE CASCADE
     )`);
 
-    // Ensure media table has all columns when upgrading from older versions
-    db.all('PRAGMA table_info(media)', [], (err, cols) => {
-      if (err) return;
-      const names = cols.map(c => c.name);
-      const add = (name, type) => {
-        if (!names.includes(name)) db.run(`ALTER TABLE media ADD COLUMN ${name} ${type}`);
-      };
-      add('original_name', 'TEXT');
-      add('mime_type', 'TEXT');
-      add('size', 'INTEGER');
-      add('user_id', 'INTEGER');
-    });
+    // Ensure tables have required columns, ignoring errors if they already exist
+    const safeAddColumn = (table, column, def) => {
+      db.run(`ALTER TABLE ${table} ADD COLUMN ${column} ${def}`, err => {
+        if (err && !/duplicate column/.test(err.message)) console.error(err);
+      });
+    };
 
-    // Ensure users table has avatar_id and is_artist columns
-    db.all('PRAGMA table_info(users)', [], (err, cols) => {
-      if (err) return;
-      const names = cols.map(c => c.name);
-      if (!names.includes('avatar_id')) {
-        db.run('ALTER TABLE users ADD COLUMN avatar_id INTEGER');
-      }
-      if (!names.includes('is_artist')) {
-        db.run('ALTER TABLE users ADD COLUMN is_artist INTEGER DEFAULT 0');
-      }
-      if (!names.includes('custom_html')) {
-        db.run('ALTER TABLE users ADD COLUMN custom_html TEXT');
-      }
-      if (!names.includes('profile_theme')) {
-        db.run('ALTER TABLE users ADD COLUMN profile_theme TEXT');
-      }
-      if (!names.includes('fan_points')) {
-        db.run('ALTER TABLE users ADD COLUMN fan_points INTEGER DEFAULT 0');
-      }
-      if (!names.includes('artist_points')) {
-        db.run('ALTER TABLE users ADD COLUMN artist_points INTEGER DEFAULT 0');
-      }
-      if (!names.includes('fan_level_id')) {
-        db.run('ALTER TABLE users ADD COLUMN fan_level_id INTEGER');
-      }
-      if (!names.includes('artist_level_id')) {
-        db.run('ALTER TABLE users ADD COLUMN artist_level_id INTEGER');
-      }
-    });
+    safeAddColumn('media', 'original_name', 'TEXT');
+    safeAddColumn('media', 'mime_type', 'TEXT');
+    safeAddColumn('media', 'size', 'INTEGER');
+    safeAddColumn('media', 'user_id', 'INTEGER');
 
-    // Ensure board_posts has updated_at and headline columns
-    db.all('PRAGMA table_info(board_posts)', [], (err, cols) => {
-      if (err) return;
-      const names = cols.map(c => c.name);
-      if (!names.includes('updated_at')) {
-        db.run('ALTER TABLE board_posts ADD COLUMN updated_at DATETIME');
-      }
-      if (!names.includes('headline')) {
-        db.run("ALTER TABLE board_posts ADD COLUMN headline TEXT DEFAULT ''");
-      }
-    });
+    safeAddColumn('users', 'avatar_id', 'INTEGER');
+    safeAddColumn('users', 'is_artist', 'INTEGER DEFAULT 0');
+    safeAddColumn('users', 'custom_html', 'TEXT');
+    safeAddColumn('users', 'profile_theme', 'TEXT');
+    safeAddColumn('users', 'fan_points', 'INTEGER DEFAULT 0');
+    safeAddColumn('users', 'artist_points', 'INTEGER DEFAULT 0');
+    safeAddColumn('users', 'fan_level_id', 'INTEGER');
+    safeAddColumn('users', 'artist_level_id', 'INTEGER');
+
+    safeAddColumn('board_posts', 'updated_at', 'DATETIME');
+    safeAddColumn('board_posts', 'headline', "TEXT DEFAULT ''");
 
     // Seed level tables with defaults if empty
     db.get('SELECT COUNT(*) AS c FROM fan_levels', (err, row) => {
@@ -240,7 +209,7 @@ const init = (options = {}) => {
       }
     });
 
-    if (options.seedDemo !== false) {
+    if (options.seedDemo !== false && dbFile !== ':memory:') {
       db.get('SELECT COUNT(*) AS c FROM users', (err, row) => {
         if (!err && row.c === 0) {
           const seed = require('./seed');

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "app.js",
   "scripts": {
     "test": "playwright test",
-    "start": "node app.js"
+    "start": "node app.js",
+    "seed": "node seed.js"
   },
   "keywords": [],
   "author": "",

--- a/seed.js
+++ b/seed.js
@@ -47,7 +47,7 @@ module.exports = seed;
 
 if (require.main === module) {
   const { db, init } = require('./db');
-  init();
+  init({ seedDemo: false });
   seed(db);
   db.close();
 }

--- a/seed.js
+++ b/seed.js
@@ -1,5 +1,4 @@
 const bcrypt = require('bcryptjs');
-const { db, init } = require('./db');
 
 const seed = dbInstance => {
   const password = bcrypt.hashSync('password123', 10);
@@ -31,13 +30,15 @@ const seed = dbInstance => {
       'INSERT INTO users (name, username, password, email, is_artist) VALUES (?, ?, ?, ?, ?)',
       ['Demo Two', 'demo2', password, 'demo2@example.com', 0]
     );
-    dbInstance.run('INSERT INTO follows (follower_id, followed_id) VALUES (1, 2)');
-    dbInstance.run('INSERT INTO follows (follower_id, followed_id) VALUES (2, 1)');
+    dbInstance.run('INSERT INTO follows (follower_id, followed_id) VALUES (?, ?)', [1, 2]);
+    dbInstance.run('INSERT INTO follows (follower_id, followed_id) VALUES (?, ?)', [2, 1]);
     dbInstance.run(
-      'INSERT INTO board_posts (user_id, headline, content) VALUES (1, \"Welcome\", \"Welcome to the board\")'
+      'INSERT INTO board_posts (user_id, headline, content) VALUES (?, ?, ?)',
+      [1, 'Welcome', 'Welcome to the board']
     );
     dbInstance.run(
-      'INSERT INTO board_posts (user_id, headline, content) VALUES (2, \"Another Post\", \"Hello from Demo Artist\")'
+      'INSERT INTO board_posts (user_id, headline, content) VALUES (?, ?, ?)',
+      [2, 'Another Post', 'Hello from Demo Artist']
     );
   });
 };
@@ -45,6 +46,8 @@ const seed = dbInstance => {
 module.exports = seed;
 
 if (require.main === module) {
+  const { db, init } = require('./db');
   init();
   seed(db);
+  db.close();
 }

--- a/seed.js
+++ b/seed.js
@@ -1,0 +1,50 @@
+const bcrypt = require('bcryptjs');
+const { db, init } = require('./db');
+
+const seed = dbInstance => {
+  const password = bcrypt.hashSync('password123', 10);
+  dbInstance.serialize(() => {
+    dbInstance.run('PRAGMA foreign_keys = OFF');
+    dbInstance.run('DELETE FROM board_comments');
+    dbInstance.run('DELETE FROM board_reactions');
+    dbInstance.run('DELETE FROM follows');
+    dbInstance.run('DELETE FROM board_posts');
+    dbInstance.run('DELETE FROM messages');
+    dbInstance.run('DELETE FROM profile_media');
+    dbInstance.run('DELETE FROM media');
+    dbInstance.run('DELETE FROM shows');
+    dbInstance.run('DELETE FROM merch');
+    dbInstance.run('DELETE FROM notifications');
+    dbInstance.run('DELETE FROM user_fan_badges');
+    dbInstance.run('DELETE FROM user_artist_badges');
+    dbInstance.run('DELETE FROM users');
+    dbInstance.run('PRAGMA foreign_keys = ON');
+    dbInstance.run(
+      'INSERT INTO users (name, username, password, email, is_artist) VALUES (?, ?, ?, ?, ?)',
+      ['Demo One', 'demo1', password, 'demo1@example.com', 0]
+    );
+    dbInstance.run(
+      'INSERT INTO users (name, username, password, email, is_artist) VALUES (?, ?, ?, ?, ?)',
+      ['Demo Artist', 'demoartist', password, 'demoartist@example.com', 1]
+    );
+    dbInstance.run(
+      'INSERT INTO users (name, username, password, email, is_artist) VALUES (?, ?, ?, ?, ?)',
+      ['Demo Two', 'demo2', password, 'demo2@example.com', 0]
+    );
+    dbInstance.run('INSERT INTO follows (follower_id, followed_id) VALUES (1, 2)');
+    dbInstance.run('INSERT INTO follows (follower_id, followed_id) VALUES (2, 1)');
+    dbInstance.run(
+      'INSERT INTO board_posts (user_id, headline, content) VALUES (1, \"Welcome\", \"Welcome to the board\")'
+    );
+    dbInstance.run(
+      'INSERT INTO board_posts (user_id, headline, content) VALUES (2, \"Another Post\", \"Hello from Demo Artist\")'
+    );
+  });
+};
+
+module.exports = seed;
+
+if (require.main === module) {
+  init();
+  seed(db);
+}


### PR DESCRIPTION
## Summary
- seed database with demo users, follows, and board posts using bcrypt
- automatically populate demo data when no users exist
- add manual seeding script and instructions

## Testing
- `npm test`
- `npm start` (killed after verifying launch)


------
https://chatgpt.com/codex/tasks/task_e_68960f976ea0832d80316403f80699e5