### PR TITLE
feat: add seed templates

### DIFF
--- a/seed.js
+++ b/seed.js
@@ -1,7 +1,54 @@
 const bcrypt = require('bcryptjs');
 
+// Template data arrays; modify or extend as needed
+const users = [
+  {
+    name: 'Demo One',
+    username: 'demo1',
+    email: 'demo1@example.com',
+    password: 'password123',
+    is_artist: 0
+  },
+  {
+    name: 'Demo Artist',
+    username: 'demoartist',
+    email: 'demoartist@example.com',
+    password: 'password123',
+    is_artist: 1
+  },
+  {
+    name: 'Demo Two',
+    username: 'demo2',
+    email: 'demo2@example.com',
+    password: 'password123',
+    is_artist: 0
+  }
+  // Add more users here
+];
+
+const posts = [
+  { user_id: 1, headline: 'Welcome', content: 'Welcome to the board' },
+  { user_id: 2, headline: 'Another Post', content: 'Hello from Demo Artist' }
+  // Add more posts here
+];
+
+const reactions = [
+  { user_id: 1, post_id: 2, reaction: 1 }
+  // Add more reactions here (reaction: 1 for like, -1 for dislike)
+];
+
+const comments = [
+  { user_id: 2, post_id: 1, content: 'Nice post!' }
+  // Add more comments here
+];
+
+const follows = [
+  { follower_id: 1, followed_id: 2 },
+  { follower_id: 2, followed_id: 1 }
+  // Add more follows here
+];
+
 const seed = dbInstance => {
-  const password = bcrypt.hashSync('password123', 10);
   dbInstance.serialize(() => {
     dbInstance.run('PRAGMA foreign_keys = OFF');
     dbInstance.run('DELETE FROM board_comments');
@@ -18,28 +65,42 @@ const seed = dbInstance => {
     dbInstance.run('DELETE FROM user_artist_badges');
     dbInstance.run('DELETE FROM users');
     dbInstance.run('PRAGMA foreign_keys = ON');
-    dbInstance.run(
-      'INSERT INTO users (name, username, password, email, is_artist) VALUES (?, ?, ?, ?, ?)',
-      ['Demo One', 'demo1', password, 'demo1@example.com', 0]
-    );
-    dbInstance.run(
-      'INSERT INTO users (name, username, password, email, is_artist) VALUES (?, ?, ?, ?, ?)',
-      ['Demo Artist', 'demoartist', password, 'demoartist@example.com', 1]
-    );
-    dbInstance.run(
-      'INSERT INTO users (name, username, password, email, is_artist) VALUES (?, ?, ?, ?, ?)',
-      ['Demo Two', 'demo2', password, 'demo2@example.com', 0]
-    );
-    dbInstance.run('INSERT INTO follows (follower_id, followed_id) VALUES (?, ?)', [1, 2]);
-    dbInstance.run('INSERT INTO follows (follower_id, followed_id) VALUES (?, ?)', [2, 1]);
-    dbInstance.run(
-      'INSERT INTO board_posts (user_id, headline, content) VALUES (?, ?, ?)',
-      [1, 'Welcome', 'Welcome to the board']
-    );
-    dbInstance.run(
-      'INSERT INTO board_posts (user_id, headline, content) VALUES (?, ?, ?)',
-      [2, 'Another Post', 'Hello from Demo Artist']
-    );
+
+    users.forEach(u => {
+      const hashed = bcrypt.hashSync(u.password, 10);
+      dbInstance.run(
+        'INSERT INTO users (name, username, password, email, is_artist) VALUES (?, ?, ?, ?, ?)',
+        [u.name, u.username, hashed, u.email, u.is_artist]
+      );
+    });
+
+    follows.forEach(f => {
+      dbInstance.run(
+        'INSERT INTO follows (follower_id, followed_id) VALUES (?, ?)',
+        [f.follower_id, f.followed_id]
+      );
+    });
+
+    posts.forEach(p => {
+      dbInstance.run(
+        'INSERT INTO board_posts (user_id, headline, content) VALUES (?, ?, ?)',
+        [p.user_id, p.headline, p.content]
+      );
+    });
+
+    reactions.forEach(r => {
+      dbInstance.run(
+        'INSERT INTO board_reactions (user_id, post_id, reaction) VALUES (?, ?, ?)',
+        [r.user_id, r.post_id, r.reaction]
+      );
+    });
+
+    comments.forEach(c => {
+      dbInstance.run(
+        'INSERT INTO board_comments (user_id, post_id, content) VALUES (?, ?, ?)',
+        [c.user_id, c.post_id, c.content]
+      );
+    });
   });
 };
 
@@ -51,3 +112,4 @@ if (require.main === module) {
   seed(db);
   db.close();
 }
+


### PR DESCRIPTION
## Summary
- restructure seed.js with template arrays for users, posts, reactions, comments, and follows
- iterate over data arrays to populate tables after clearing demo data

## Testing
- `npm test`
- `npm start`

------
https://chatgpt.com/codex/tasks/task_e_6896543ea060832da56da64aa043777a