### PR TITLE
Restrict custom HTML sanitization in user profiles

### DIFF
--- a/routes/users.js
+++ b/routes/users.js
@@ -73,9 +73,12 @@ router.post(
     const { name, email, bio, social, custom_html, profile_theme } = req.body;
     const safeHtml = custom_html
       ? sanitizeHtml(custom_html, {
-          allowedTags: false,
-          allowedAttributes: { '*': ['id', 'class', 'style', 'href', 'src'] },
-          exclusiveFilter: f => f.tag === 'script' || f.tag === 'style'
+          allowedTags: sanitizeHtml.defaults.allowedTags,
+          allowedAttributes: {
+            '*': ['id', 'class', 'style'],
+            a: ['href'],
+            img: ['src']
+          }
         })
       : undefined;
     db.get(


### PR DESCRIPTION
## Summary
- use sanitize-html's default allowedTags instead of allowing all tags for custom_html
- narrow allowedAttributes to id, class, style globally with href for links and src for images

## Testing
- `npm test`
- `npm start`

------
https://chatgpt.com/codex/tasks/task_e_689656bd7ad4832da10b06e22a79fe4d