### PR TITLE
Use execFile for clamscan scanning

### DIFF
--- a/routes/media.js
+++ b/routes/media.js
@@ -3,7 +3,7 @@ const router = express.Router();
 const multer = require('multer');
 const path = require('path');
 const fs = require('fs');
-const { exec } = require('child_process');
+const { execFile } = require('child_process');
 const { db } = require('../db');
 const authenticate = require('../middleware/auth');
 const { param } = require('express-validator');
@@ -51,7 +51,7 @@ router.post('/', authenticate, upload.single('file'), (req, res, next) => {
 
   const filePath = path.join(uploadDir, req.file.filename);
   // Virus scan using clamscan if available
-  exec(`clamscan ${filePath}`, (err, stdout) => {
+  execFile('clamscan', [filePath], (err, stdout) => {
     if (err && err.code === 127) {
       // clamscan not installed, skip scanning
     } else if (err && err.code !== 1 && err.code !== 2) {

--- a/routes/profileMedia.js
+++ b/routes/profileMedia.js
@@ -3,7 +3,7 @@ const router = express.Router();
 const multer = require('multer');
 const path = require('path');
 const fs = require('fs');
-const { exec } = require('child_process');
+const { execFile } = require('child_process');
 const { db } = require('../db');
 const authenticate = require('../middleware/auth');
 const { param } = require('express-validator');
@@ -52,7 +52,7 @@ router.post('/', authenticate, upload.single('file'), (req, res, next) => {
   }
 
   const filePath = path.join(uploadDir, req.file.filename);
-  exec(`clamscan ${filePath}`, (err, stdout) => {
+  execFile('clamscan', [filePath], (err, stdout) => {
     if (err && err.code === 127) {
       // clamscan not installed
     } else if (err && err.code !== 1 && err.code !== 2) {

--- a/routes/users.js
+++ b/routes/users.js
@@ -7,7 +7,7 @@ const validate = require('../middleware/validate');
 const multer = require('multer');
 const path = require('path');
 const fs = require('fs');
-const { exec } = require('child_process');
+const { execFile } = require('child_process');
 const sanitizeHtml = require('sanitize-html');
 
 const uploadDir = path.join(__dirname, '..', 'uploads');
@@ -124,7 +124,7 @@ router.post('/avatar', authenticate, upload.single('avatar'), (req, res, next) =
     return next(errFile);
   }
   const filePath = path.join(uploadDir, req.file.filename);
-  exec(`clamscan ${filePath}`, (err, stdout) => {
+  execFile('clamscan', [filePath], (err, stdout) => {
     if (err && err.code === 127) {
       // clamscan not installed, skip scanning
     } else if (err && err.code !== 1 && err.code !== 2) {


### PR DESCRIPTION
## Summary
- Replace shell-based `exec` calls with `execFile` when invoking `clamscan`.
- Preserve existing error handling around virus scan results.

## Testing
- `npm start`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6896597c09d0832dbdfd377326910188