### PR TITLE
feat: add board feed filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,8 @@ user who uploaded each file.
 - `GET /board` – list all board posts (each includes `updated_at` if edited)
 - `GET /board/user/:id` – posts by a specific user
 - `GET /board/feed` – posts from users you follow (requires authentication)
+- `GET /board/feed/artists` – posts from followed artists (requires authentication)
+- `GET /board/feed/friends` – posts from followed non-artist friends (requires authentication)
 - `POST /board` – create a new board post with `headline` and `content` (requires authentication)
 - `POST /board/:id/like` – like a post (requires authentication)
 - `POST /board/:id/dislike` – dislike a post (requires authentication)

--- a/openapi.json
+++ b/openapi.json
@@ -266,6 +266,12 @@
     "/board/feed": {
       "get": {"summary": "Posts from followed users", "security": [{"BearerAuth": []}], "responses": {"200": {"description": "Posts"}}}
     },
+    "/board/feed/artists": {
+      "get": {"summary": "Posts from followed artists", "security": [{"BearerAuth": []}], "responses": {"200": {"description": "Posts"}}}
+    },
+    "/board/feed/friends": {
+      "get": {"summary": "Posts from followed non-artist friends", "security": [{"BearerAuth": []}], "responses": {"200": {"description": "Posts"}}}
+    },
     "/board/{id}/like": {
       "post": {"summary": "Like a post", "security": [{"BearerAuth": []}], "parameters": [{"name": "id", "in": "path", "required": true, "schema": {"type": "integer"}}], "responses": {"200": {"description": "Success"}}}
     },

--- a/routes/board.js
+++ b/routes/board.js
@@ -58,6 +58,42 @@ router.get('/feed', authenticate, (req, res, next) => {
   });
 });
 
+// Get posts from followed artists
+router.get('/feed/artists', authenticate, (req, res, next) => {
+  const sql = `
+    SELECT board_posts.*, users.username,
+      (SELECT COUNT(*) FROM board_reactions WHERE post_id = board_posts.id AND reaction = 1) AS likes,
+      (SELECT COUNT(*) FROM board_reactions WHERE post_id = board_posts.id AND reaction = -1) AS dislikes,
+      (SELECT COUNT(*) FROM board_comments WHERE post_id = board_posts.id) AS comments
+    FROM board_posts
+    JOIN users ON board_posts.user_id = users.id
+    JOIN follows ON follows.followed_id = board_posts.user_id
+    WHERE follows.follower_id = ? AND users.is_artist = 1
+    ORDER BY created_at DESC`;
+  db.all(sql, [req.user.id], (err, rows) => {
+    if (err) return next(err);
+    res.json(rows);
+  });
+});
+
+// Get posts from followed non-artist friends
+router.get('/feed/friends', authenticate, (req, res, next) => {
+  const sql = `
+    SELECT board_posts.*, users.username,
+      (SELECT COUNT(*) FROM board_reactions WHERE post_id = board_posts.id AND reaction = 1) AS likes,
+      (SELECT COUNT(*) FROM board_reactions WHERE post_id = board_posts.id AND reaction = -1) AS dislikes,
+      (SELECT COUNT(*) FROM board_comments WHERE post_id = board_posts.id) AS comments
+    FROM board_posts
+    JOIN users ON board_posts.user_id = users.id
+    JOIN follows ON follows.followed_id = board_posts.user_id
+    WHERE follows.follower_id = ? AND users.is_artist = 0
+    ORDER BY created_at DESC`;
+  db.all(sql, [req.user.id], (err, rows) => {
+    if (err) return next(err);
+    res.json(rows);
+  });
+});
+
 // Create a board post
 router.post(
   '/',

--- a/tests/integration/api.test.js
+++ b/tests/integration/api.test.js
@@ -17,6 +17,7 @@ async function register(data) {
 
 test.beforeAll(async () => {
   process.env.DB_FILE = ':memory:';
+  process.env.RATE_LIMIT_MAX = 1000;
   const fs = require('fs');
   const path = require('path');
   const bin = path.join(__dirname, 'bin');
@@ -544,6 +545,60 @@ test('feed endpoints return followed content', async () => {
 
   const merch = await (await context.get('/merch/feed', { headers: { Authorization: `Bearer ${ta}` } })).json();
   expect(merch.length).toBe(1);
+});
+
+test('board feed filters artists and friends', async () => {
+  const { token: follower } = await register({
+    name: 'Follower',
+    username: 'follower',
+    password: 'pw'
+  });
+
+  const { token: friendToken, id: friendId } = await register({
+    name: 'Friend',
+    username: 'friend',
+    password: 'pw'
+  });
+
+  const { token: artistToken, id: artistId } = await register({
+    name: 'Artist',
+    username: 'artistfeed',
+    password: 'pw',
+    is_artist: true
+  });
+
+  await context.post('/board', {
+    headers: { Authorization: `Bearer ${friendToken}` },
+    data: { headline: 'Friend post', content: 'hello' }
+  });
+  await context.post('/board', {
+    headers: { Authorization: `Bearer ${artistToken}` },
+    data: { headline: 'Artist post', content: 'art' }
+  });
+
+  await context.post(`/follow/${friendId}`, {
+    headers: { Authorization: `Bearer ${follower}` }
+  });
+  await context.post(`/follow/${artistId}`, {
+    headers: { Authorization: `Bearer ${follower}` }
+  });
+
+  const combined = await (await context.get('/board/feed', {
+    headers: { Authorization: `Bearer ${follower}` }
+  })).json();
+  expect(combined.length).toBe(2);
+
+  const artFeed = await (await context.get('/board/feed/artists', {
+    headers: { Authorization: `Bearer ${follower}` }
+  })).json();
+  expect(artFeed.length).toBe(1);
+  expect(artFeed[0].user_id).toBe(artistId);
+
+  const friendFeed = await (await context.get('/board/feed/friends', {
+    headers: { Authorization: `Bearer ${follower}` }
+  })).json();
+  expect(friendFeed.length).toBe(1);
+  expect(friendFeed[0].user_id).toBe(friendId);
 });
 
 test('leaderboard tracks points', async () => {


### PR DESCRIPTION
## Summary
- add endpoints for filtering board feeds by followed artists and non-artist friends
- document new feed routes in README and OpenAPI spec
- test artist and friend filtering

## Testing
- `npm start`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689a1de69784832da70593bb6370345f