### PR TITLE
Secure board feed

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,7 +199,6 @@ user who uploaded each file.
 
 ### `/board`
 
-- `GET /board` – list all board posts (each includes `updated_at` if edited)
 - `GET /board/user/:id` – posts by a specific user
 - `GET /board/feed` – posts from users you follow (requires authentication)
 - `POST /board` – create a new board post with `headline` and `content` (requires authentication)

--- a/openapi.json
+++ b/openapi.json
@@ -260,7 +260,6 @@
       "get": {"summary": "Merch from followed users", "security": [{"BearerAuth": []}], "responses": {"200": {"description": "Items"}}}
     },
     "/board": {
-      "get": {"summary": "List board posts", "description": "Posts include `updated_at` when edited", "responses": {"200": {"description": "Posts"}}},
       "post": {"summary": "Create board post", "security": [{"BearerAuth": []}], "requestBody": {"required": true, "content": {"application/json": {"schema": {"type": "object", "required": ["headline", "content"], "properties": {"headline": {"type": "string"}, "content": {"type": "string"}}}}}}, "responses": {"200": {"description": "Created"}}}
     },
     "/board/user/{id}": {

--- a/public/app.js
+++ b/public/app.js
@@ -867,12 +867,24 @@ function Board({ auth }) {
   const [postEditHeadline, setPostEditHeadline] = React.useState('');
 
   const load = () => {
-    fetch('/board')
-      .then(r => r.json())
+    if (!auth.token) {
+      alert('Sign in first');
+      return;
+    }
+    fetch('/board/feed', {
+      headers: { Authorization: `Bearer ${auth.token}` }
+    })
+      .then(r => {
+        if (r.status === 401) {
+          alert('Sign in first');
+          return [];
+        }
+        return r.json();
+      })
       .then(setPosts);
   };
 
-  React.useEffect(load, []);
+  React.useEffect(load, [auth.token]);
 
   const loadComments = id => {
     fetch(`/board/${id}/comments`)

--- a/routes/board.js
+++ b/routes/board.js
@@ -7,22 +7,6 @@ const validate = require('../middleware/validate');
 const notify = require('../utils/notify');
 const { addPoints, awardBadge } = require('../utils/gamify');
 
-// List all board posts
-router.get('/', (req, res, next) => {
-  const sql = `
-    SELECT board_posts.*, users.username,
-      (SELECT COUNT(*) FROM board_reactions WHERE post_id = board_posts.id AND reaction = 1) AS likes,
-      (SELECT COUNT(*) FROM board_reactions WHERE post_id = board_posts.id AND reaction = -1) AS dislikes,
-      (SELECT COUNT(*) FROM board_comments WHERE post_id = board_posts.id) AS comments
-    FROM board_posts
-    JOIN users ON board_posts.user_id = users.id
-    ORDER BY created_at DESC`;
-  db.all(sql, [], (err, rows) => {
-    if (err) return next(err);
-    res.json(rows);
-  });
-});
-
 // Get posts by user
 router.get('/user/:id', param('id').isInt(), validate, (req, res, next) => {
   const sql = `

--- a/tests/integration/api.test.js
+++ b/tests/integration/api.test.js
@@ -99,7 +99,7 @@ test('messaging and media upload', async () => {
 });
 
 test('board post creation', async () => {
-  const { token } = await register({
+  const { token, id } = await register({
     name: 'Dana',
     username: 'dana',
     password: 'pw'
@@ -109,14 +109,14 @@ test('board post creation', async () => {
     data: { headline: 'Test', content: 'Hello board' }
   });
   expect(post.ok()).toBeTruthy();
-  const all = await context.get('/board');
+  const all = await context.get(`/board/user/${id}`);
   expect(all.ok()).toBeTruthy();
   const items = await all.json();
   expect(items.find(p => p.headline === 'Test' && p.content === 'Hello board')).toBeTruthy();
 });
 
 test('board post interactions', async () => {
-  const { token: t1 } = await register({
+  const { token: t1, id: id1 } = await register({
     name: 'Ed',
     username: 'ed',
     password: 'pw'
@@ -144,7 +144,7 @@ test('board post interactions', async () => {
   });
   expect(comment.ok()).toBeTruthy();
 
-  const posts = await context.get('/board');
+  const posts = await context.get(`/board/user/${id1}`);
   const arr = await posts.json();
   const p = arr.find(x => x.id === id);
   expect(p.likes).toBe(1);
@@ -155,7 +155,7 @@ test('board post interactions', async () => {
 });
 
 test('board post editing', async () => {
-  const { token } = await register({
+  const { token, id: userId } = await register({
     name: 'Mia',
     username: 'mia',
     password: 'pw'
@@ -170,7 +170,7 @@ test('board post editing', async () => {
     data: { headline: 'Changed', content: 'Edited' }
   });
   expect(edit.ok()).toBeTruthy();
-  const posts = await context.get('/board');
+  const posts = await context.get(`/board/user/${userId}`);
   const arr = await posts.json();
   const updated = arr.find(p => p.id === id);
   expect(updated.headline).toBe('Changed');
@@ -179,7 +179,7 @@ test('board post editing', async () => {
 });
 
 test('comment editing and post deletion', async () => {
-  const { token: t1 } = await register({
+  const { token: t1, id: id1 } = await register({
     name: 'Ken',
     username: 'ken',
     password: 'pw'
@@ -222,7 +222,7 @@ test('comment editing and post deletion', async () => {
     headers: { Authorization: `Bearer ${t1}` }
   });
   expect(del.ok()).toBeTruthy();
-  const posts = await context.get('/board');
+  const posts = await context.get(`/board/user/${id1}`);
   const after = await posts.json();
   expect(after.find(p => p.id === id)).toBeUndefined();
 });


### PR DESCRIPTION
## Summary
- Load board posts from authenticated `/board/feed` endpoint with sign-in prompts
- Remove public board listing endpoint and update docs and tests

## Testing
- `npm start`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689a1e7715e4832dbb3d42e0704c5898