### PR TITLE
Verify follow status before profile section fetches

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -318,11 +318,11 @@ function Profile({ auth }) {
       </div>
       <div>
         <div className="font-bold mb-1">Merch</div>
-        <MerchSection userId={auth.userId} />
+        <MerchSection userId={auth.userId} auth={auth} />
       </div>
       <div>
         <div className="font-bold mb-1">Upcoming Shows</div>
-        <ShowsSection userId={auth.userId} />
+        <ShowsSection userId={auth.userId} auth={auth} />
       </div>
     </div>
   );
@@ -554,11 +554,11 @@ function UserDetail() {
       </div>
       <div>
         <div className="font-bold mb-1">Merch</div>
-        <MerchSection userId={id} />
+        <MerchSection userId={id} auth={{ token, userId: viewerId }} />
       </div>
       <div>
         <div className="font-bold mb-1">Upcoming Shows</div>
-        <ShowsSection userId={id} />
+        <ShowsSection userId={id} auth={{ token, userId: viewerId }} />
       </div>
     </div>
   );
@@ -618,11 +618,11 @@ function ArtistDetail() {
       </div>
       <div>
         <div className="font-bold mb-1">Merch</div>
-        <MerchSection userId={id} />
+        <MerchSection userId={id} auth={{ token, userId: viewerId }} />
       </div>
       <div>
         <div className="font-bold mb-1">Upcoming Shows</div>
-        <ShowsSection userId={id} />
+        <ShowsSection userId={id} auth={{ token, userId: viewerId }} />
       </div>
     </div>
   );
@@ -812,13 +812,41 @@ function MediaGallery({ userId, auth }) {
   );
 }
 
-function MerchSection({ userId }) {
+function MerchSection({ userId, auth }) {
   const [items, setItems] = React.useState([]);
+  const [error, setError] = React.useState('');
   React.useEffect(() => {
-    fetch(`/merch/user/${userId}`)
-      .then(r => r.json())
-      .then(setItems);
-  }, [userId]);
+    setItems([]);
+    setError('');
+    if (auth && String(auth.userId) === String(userId)) {
+      fetch(`/merch/user/${userId}`)
+        .then(r => r.json())
+        .then(setItems);
+      return;
+    }
+    if (!auth || !auth.token) {
+      setError('Please sign in to view merch.');
+      return;
+    }
+    fetch(`/follow/${userId}`, { headers: { Authorization: `Bearer ${auth.token}` } })
+      .then(r => {
+        if (r.status === 401) {
+          setError('Please sign in to view merch.');
+          return null;
+        }
+        return r.json();
+      })
+      .then(d => {
+        if (d && d.following) {
+          fetch(`/merch/user/${userId}`)
+            .then(r => r.json())
+            .then(setItems);
+        } else if (d) {
+          setError('Follow this user to view their merch.');
+        }
+      });
+  }, [userId, auth && auth.token, auth && auth.userId]);
+  if (error) return <div>{error}</div>;
   if (!items.length) return <div>No merch yet.</div>;
   return (
     <div className="space-y-2">
@@ -833,13 +861,41 @@ function MerchSection({ userId }) {
   );
 }
 
-function ShowsSection({ userId }) {
+function ShowsSection({ userId, auth }) {
   const [shows, setShows] = React.useState([]);
+  const [error, setError] = React.useState('');
   React.useEffect(() => {
-    fetch(`/shows/user/${userId}`)
-      .then(r => r.json())
-      .then(setShows);
-  }, [userId]);
+    setShows([]);
+    setError('');
+    if (auth && String(auth.userId) === String(userId)) {
+      fetch(`/shows/user/${userId}`)
+        .then(r => r.json())
+        .then(setShows);
+      return;
+    }
+    if (!auth || !auth.token) {
+      setError('Please sign in to view shows.');
+      return;
+    }
+    fetch(`/follow/${userId}`, { headers: { Authorization: `Bearer ${auth.token}` } })
+      .then(r => {
+        if (r.status === 401) {
+          setError('Please sign in to view shows.');
+          return null;
+        }
+        return r.json();
+      })
+      .then(d => {
+        if (d && d.following) {
+          fetch(`/shows/user/${userId}`)
+            .then(r => r.json())
+            .then(setShows);
+        } else if (d) {
+          setError('Follow this user to view their shows.');
+        }
+      });
+  }, [userId, auth && auth.token, auth && auth.userId]);
+  if (error) return <div>{error}</div>;
   if (!shows.length) return <div>No upcoming shows.</div>;
   return (
     <div className="space-y-2">

--- a/tests/integration/follow_sections.test.js
+++ b/tests/integration/follow_sections.test.js
@@ -1,0 +1,73 @@
+const http = require('http');
+const { test, expect, request, chromium } = require('@playwright/test');
+
+let server;
+let api;
+let browser;
+let page;
+let skip = false;
+let baseURL;
+
+async function register(data) {
+  const res = await api.post('/auth/register', { data });
+  expect(res.ok()).toBeTruthy();
+  return await res.json();
+}
+
+test.beforeAll(async () => {
+  process.env.DB_FILE = ':memory:';
+  const fs = require('fs');
+  const path = require('path');
+  const bin = path.join(__dirname, 'bin');
+  fs.mkdirSync(bin, { recursive: true });
+  const fake = path.join(bin, 'clamscan');
+  fs.writeFileSync(fake, '#!/bin/sh\nexit 0');
+  fs.chmodSync(fake, 0o755);
+  process.env.PATH = `${bin}:${process.env.PATH}`;
+
+  const app = require('../../app');
+  server = http.createServer(app);
+  await new Promise(resolve => server.listen(0, resolve));
+  baseURL = `http://localhost:${server.address().port}`;
+  api = await request.newContext({ baseURL });
+  try {
+    browser = await chromium.launch();
+    page = await browser.newPage();
+  } catch (e) {
+    skip = true;
+  }
+});
+
+test.afterAll(async () => {
+  await api.dispose();
+  if (browser) await browser.close();
+  server.close();
+});
+
+test('media, merch and shows require following', async ({}, testInfo) => {
+  testInfo.skip(skip, 'browser not available');
+  const artist = await register({ name: 'Art', username: 'artistf', password: 'pw', is_artist: true });
+  const viewer = await register({ name: 'View', username: 'viewerf', password: 'pw' });
+
+  await api.post('/merch', {
+    headers: { Authorization: `Bearer ${artist.token}` },
+    data: { product_name: 'Shirt', price: 10, stock: 1 }
+  });
+
+  await api.post('/shows', {
+    headers: { Authorization: `Bearer ${artist.token}` },
+    data: { venue: 'Club', date: '2030-01-01', description: 'Gig' }
+  });
+
+  await page.goto('about:blank');
+  await page.evaluate(({ t, uid }) => {
+    localStorage.setItem('token', t);
+    localStorage.setItem('userId', String(uid));
+  }, { t: viewer.token, uid: viewer.id });
+
+  await page.goto(`${baseURL}/artists/${artist.id}`);
+
+  await page.waitForSelector('text=Follow this user to view their media.');
+  await page.waitForSelector('text=Follow this user to view their merch.');
+  await page.waitForSelector('text=Follow this user to view their shows.');
+});


### PR DESCRIPTION
## Summary
- check follow status before fetching media, merch or show data
- pass auth info to profile sections to enforce follow requirements
- test that non-followers cannot view media, merch or shows

## Testing
- `npm start`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689a2a4b17e8832da57654cd39a16337