### PR TITLE
feat: darken landing hero text and gradient

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -144,7 +144,7 @@ function TrendingPosts({ auth }) {
 function GuestLanding() {
   return (
     <React.Fragment>
-      <section className="w-full bg-gradient-to-r from-blue-500 to-purple-600 text-white text-center py-20 hero-section">
+      <section className="w-full bg-gradient-to-r from-indigo-700 to-purple-800 text-gray-100 text-center py-20 hero-section">
         <h1 className="text-4xl font-bold mb-4 hero-title">Under the Radar</h1>
         <p className="text-lg mb-2">A home for underground musicians to share their art without algorithms.</p>
         <p className="mb-6">Create a profile, upload your tracks and photos, list shows and sell merch directly to fans.</p>
@@ -159,7 +159,7 @@ function GuestLanding() {
 function ArtistLanding({ auth }) {
   return (
     <React.Fragment>
-      <section className="w-full bg-gradient-to-r from-blue-500 to-purple-600 text-white text-center py-20 hero-section">
+      <section className="w-full bg-gradient-to-r from-indigo-700 to-purple-800 text-gray-100 text-center py-20 hero-section">
         <h1 className="text-4xl font-bold mb-4 hero-title">Welcome back!</h1>
         <p className="mb-6">Share new posts and connect with your fans.</p>
         <Link className="bg-white text-blue-600 px-4 py-2 rounded hover:bg-gray-100" to="/profile">
@@ -174,7 +174,7 @@ function ArtistLanding({ auth }) {
 function UserLanding({ auth }) {
   return (
     <React.Fragment>
-      <section className="w-full bg-gradient-to-r from-blue-500 to-purple-600 text-white text-center py-20 hero-section">
+      <section className="w-full bg-gradient-to-r from-indigo-700 to-purple-800 text-gray-100 text-center py-20 hero-section">
         <h1 className="text-4xl font-bold mb-4 hero-title">Welcome back!</h1>
         <p className="mb-6">Discover new artists and posts from the community.</p>
         <Link className="bg-white text-blue-600 px-4 py-2 rounded hover:bg-gray-100" to="/browse">


### PR DESCRIPTION
## Summary
- improve contrast for hero tagline by using darker gradient and text colors

## Testing
- `npm start`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689b7a3c8fc4832da87d71c1c11722ef