### PR TITLE
Add ragged border styling to posts, profiles, and comments

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -300,7 +300,7 @@ function Profile({ auth }) {
 
   return (
     <div className={`p-4 space-y-6 max-w-3xl mx-auto ${profile.profile_theme || 'theme-default'}`}>
-      <div className="flex flex-col items-center space-y-2">
+      <div className="flex flex-col items-center space-y-2 border-ragged corner-grunge p-4">
         {profile.avatar_id ? (
           <img className="w-32 h-32 object-cover rounded-full" src={`/media/${profile.avatar_id}`} alt="avatar" />
         ) : (
@@ -1027,7 +1027,7 @@ function Board({ auth }) {
           )}
           <div className="space-y-2">
             {posts.map(p => (
-              <div key={p.id} className="border p-2 bg-white">
+              <div key={p.id} className="border-ragged corner-grunge p-2 bg-white">
                 <div
                   className="font-semibold text-lg cursor-pointer"
                   onClick={() => {
@@ -1092,7 +1092,7 @@ function Board({ auth }) {
                 {expanded === p.id && (
                   <div className="mt-2 space-y-1">
                     {(comments[p.id] || []).map(c => (
-                      <div key={c.id} className="border-t pt-1 text-sm">
+                      <div key={c.id} className="border-ragged corner-grunge p-1 text-sm">
                         <span className="font-bold mr-1">{c.username}:</span>
                         {editing === c.id ? (
                           <React.Fragment>

--- a/public/style.css
+++ b/public/style.css
@@ -39,3 +39,34 @@ body {
 .bg-grunge-light {
   background-color: #2d2d2d;
 }
+
+.border-ragged {
+  position: relative;
+  border: 2px solid #000;
+}
+
+.border-ragged::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background: repeating-linear-gradient(
+    -45deg,
+    transparent,
+    transparent 3px,
+    rgba(0, 0, 0, 0.15) 3px,
+    rgba(0, 0, 0, 0.15) 4px
+  );
+}
+
+.corner-grunge::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background:
+    url("data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmcnIHZpZXdCb3g9JzAgMCAxMCAxMCc+PHBhdGggZD0nTTAgMCBMMTAgMTAgTTEwIDAgTDAgMTAnIHN0cm9rZT0nYmxhY2snIHN0cm9rZS13aWR0aD0nMScgZmlsbD0nbm9uZScvPjwvc3ZnPg==") top left/8px 8px no-repeat,
+    url("data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmcnIHZpZXdCb3g9JzAgMCAxMCAxMCc+PHBhdGggZD0nTTAgMCBMMTAgMTAgTTEwIDAgTDAgMTAnIHN0cm9rZT0nYmxhY2snIHN0cm9rZS13aWR0aD0nMScgZmlsbD0nbm9uZScvPjwvc3ZnPg==") top right/8px 8px no-repeat,
+    url("data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmcnIHZpZXdCb3g9JzAgMCAxMCAxMCc+PHBhdGggZD0nTTAgMCBMMTAgMTAgTTEwIDAgTDAgMTAnIHN0cm9rZT0nYmxhY2snIHN0cm9rZS13aWR0aD0nMScgZmlsbD0nbm9uZScvPjwvc3ZnPg==") bottom left/8px 8px no-repeat,
+    url("data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmcnIHZpZXdCb3g9JzAgMCAxMCAxMCc+PHBhdGggZD0nTTAgMCBMMTAgMTAgTTEwIDAgTDAgMTAnIHN0cm9rZT0nYmxhY2snIHN0cm9rZS13aWR0aD0nMScgZmlsbD0nbm9uZScvPjwvc3ZnPg==") bottom right/8px 8px no-repeat;
+}


### PR DESCRIPTION
## Summary
- add `border-ragged` and `corner-grunge` classes for thick, distressed borders
- apply new styles to profile panels, post cards, and comment blocks

## Testing
- `npm start`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689b9a1320e0832d8c4dbaaad8108cfd