### PR TITLE
Show user details on board posts and comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ to:
 - Sell merchandise directly
 - Participate in a message board without algorithmic feeds
 - Post updates to a shared bulletin board
+- See avatars and artist status on board posts and comments
 - Follow other users and receive notifications for new activity
 - View posts, shows and merch from people you follow
 - Customize profile pages with sanitized HTML snippets or preset color themes
@@ -198,6 +199,8 @@ user who uploaded each file.
 - `POST /merch` – create a merch item (requires authentication)
 
 ### `/board`
+
+- All post and comment responses include `name`, `avatar_id` and `is_artist` to identify authors.
 
 - `GET /board/user/:id` – posts by a specific user
 - `GET /board/feed` – posts from users you follow (requires authentication)

--- a/openapi.json
+++ b/openapi.json
@@ -263,16 +263,16 @@
       "post": {"summary": "Create board post", "security": [{"BearerAuth": []}], "requestBody": {"required": true, "content": {"application/json": {"schema": {"type": "object", "required": ["headline", "content"], "properties": {"headline": {"type": "string"}, "content": {"type": "string"}}}}}}, "responses": {"200": {"description": "Created"}}}
     },
     "/board/user/{id}": {
-      "get": {"summary": "Posts by user", "parameters": [{"name": "id", "in": "path", "required": true, "schema": {"type": "integer"}}], "responses": {"200": {"description": "Posts"}}}
+      "get": {"summary": "Posts by user", "parameters": [{"name": "id", "in": "path", "required": true, "schema": {"type": "integer"}}], "responses": {"200": {"description": "Posts include name, avatar_id and is_artist"}}}
     },
     "/board/feed": {
-      "get": {"summary": "Posts from followed users", "security": [{"BearerAuth": []}], "responses": {"200": {"description": "Posts"}}}
+      "get": {"summary": "Posts from followed users", "security": [{"BearerAuth": []}], "responses": {"200": {"description": "Posts include name, avatar_id and is_artist"}}}
     },
     "/board/feed/artists": {
-      "get": {"summary": "Posts from followed artists", "security": [{"BearerAuth": []}], "responses": {"200": {"description": "Posts"}}}
+      "get": {"summary": "Posts from followed artists", "security": [{"BearerAuth": []}], "responses": {"200": {"description": "Posts include name, avatar_id and is_artist"}}}
     },
     "/board/feed/friends": {
-      "get": {"summary": "Posts from followed non-artist friends", "security": [{"BearerAuth": []}], "responses": {"200": {"description": "Posts"}}}
+      "get": {"summary": "Posts from followed non-artist friends", "security": [{"BearerAuth": []}], "responses": {"200": {"description": "Posts include name, avatar_id and is_artist"}}}
     },
     "/board/{id}/like": {
       "post": {"summary": "Like a post", "security": [{"BearerAuth": []}], "parameters": [{"name": "id", "in": "path", "required": true, "schema": {"type": "integer"}}], "responses": {"200": {"description": "Success"}}}
@@ -281,7 +281,7 @@
       "post": {"summary": "Dislike a post", "security": [{"BearerAuth": []}], "parameters": [{"name": "id", "in": "path", "required": true, "schema": {"type": "integer"}}], "responses": {"200": {"description": "Success"}}}
     },
     "/board/{id}/comments": {
-      "get": {"summary": "List comments", "parameters": [{"name": "id", "in": "path", "required": true, "schema": {"type": "integer"}}], "responses": {"200": {"description": "Comments"}}},
+      "get": {"summary": "List comments", "parameters": [{"name": "id", "in": "path", "required": true, "schema": {"type": "integer"}}], "responses": {"200": {"description": "Comments include name, avatar_id and is_artist"}}},
       "post": {"summary": "Add comment", "security": [{"BearerAuth": []}], "parameters": [{"name": "id", "in": "path", "required": true, "schema": {"type": "integer"}}], "requestBody": {"required": true, "content": {"application/json": {"schema": {"type": "object", "required": ["content"], "properties": {"content": {"type": "string"}}}}}}, "responses": {"200": {"description": "Created"}}}
     },
     "/board/comments/{id}": {

--- a/public/app.js
+++ b/public/app.js
@@ -1037,8 +1037,19 @@ function Board({ auth }) {
                 >
                   {p.headline}
                 </div>
-                <div className="text-sm text-gray-600">
-                  {p.username} - {new Date(p.created_at).toLocaleString()} {p.updated_at ? '(edited)' : ''}
+                <div className="flex items-center text-sm text-gray-600">
+                  {p.avatar_id && (
+                    <img
+                      className="w-6 h-6 rounded-full mr-1"
+                      src={`/media/${p.avatar_id}`}
+                      alt="avatar"
+                    />
+                  )}
+                  <span className="mr-1">{p.name}</span>
+                  <span className="text-xs">({p.is_artist ? 'artist' : 'user'})</span>
+                  <span className="ml-1">
+                    - {new Date(p.created_at).toLocaleString()} {p.updated_at ? '(edited)' : ''}
+                  </span>
                 </div>
                 {postEditing === p.id ? (
                   <div className="space-x-1 mt-1">
@@ -1093,7 +1104,19 @@ function Board({ auth }) {
                   <div className="mt-2 space-y-1">
                     {(comments[p.id] || []).map(c => (
                       <div key={c.id} className="border-ragged corner-grunge p-1 text-sm">
-                        <span className="font-bold mr-1">{c.username}:</span>
+                        <div className="flex items-center mb-1">
+                          {c.avatar_id && (
+                            <img
+                              className="w-4 h-4 rounded-full mr-1"
+                              src={`/media/${c.avatar_id}`}
+                              alt="avatar"
+                            />
+                          )}
+                          <span className="font-bold mr-1">{c.name}</span>
+                          <span className="text-xs text-gray-600">
+                            ({c.is_artist ? 'artist' : 'user'})
+                          </span>
+                        </div>
                         {editing === c.id ? (
                           <React.Fragment>
                             <input

--- a/routes/board.js
+++ b/routes/board.js
@@ -10,7 +10,7 @@ const { addPoints, awardBadge } = require('../utils/gamify');
 // Get posts by user
 router.get('/user/:id', param('id').isInt(), validate, (req, res, next) => {
   const sql = `
-    SELECT board_posts.*, users.username,
+    SELECT board_posts.*, users.username, users.name, users.avatar_id, users.is_artist,
       (SELECT COUNT(*) FROM board_reactions WHERE post_id = board_posts.id AND reaction = 1) AS likes,
       (SELECT COUNT(*) FROM board_reactions WHERE post_id = board_posts.id AND reaction = -1) AS dislikes,
       (SELECT COUNT(*) FROM board_comments WHERE post_id = board_posts.id) AS comments
@@ -27,7 +27,7 @@ router.get('/user/:id', param('id').isInt(), validate, (req, res, next) => {
 // Get posts from followed users
 router.get('/feed', authenticate, (req, res, next) => {
   const sql = `
-    SELECT board_posts.*, users.username,
+    SELECT board_posts.*, users.username, users.name, users.avatar_id, users.is_artist,
       (SELECT COUNT(*) FROM board_reactions WHERE post_id = board_posts.id AND reaction = 1) AS likes,
       (SELECT COUNT(*) FROM board_reactions WHERE post_id = board_posts.id AND reaction = -1) AS dislikes,
       (SELECT COUNT(*) FROM board_comments WHERE post_id = board_posts.id) AS comments
@@ -45,7 +45,7 @@ router.get('/feed', authenticate, (req, res, next) => {
 // Get posts from followed artists
 router.get('/feed/artists', authenticate, (req, res, next) => {
   const sql = `
-    SELECT board_posts.*, users.username,
+    SELECT board_posts.*, users.username, users.name, users.avatar_id, users.is_artist,
       (SELECT COUNT(*) FROM board_reactions WHERE post_id = board_posts.id AND reaction = 1) AS likes,
       (SELECT COUNT(*) FROM board_reactions WHERE post_id = board_posts.id AND reaction = -1) AS dislikes,
       (SELECT COUNT(*) FROM board_comments WHERE post_id = board_posts.id) AS comments
@@ -63,7 +63,7 @@ router.get('/feed/artists', authenticate, (req, res, next) => {
 // Get posts from followed non-artist friends
 router.get('/feed/friends', authenticate, (req, res, next) => {
   const sql = `
-    SELECT board_posts.*, users.username,
+    SELECT board_posts.*, users.username, users.name, users.avatar_id, users.is_artist,
       (SELECT COUNT(*) FROM board_reactions WHERE post_id = board_posts.id AND reaction = 1) AS likes,
       (SELECT COUNT(*) FROM board_reactions WHERE post_id = board_posts.id AND reaction = -1) AS dislikes,
       (SELECT COUNT(*) FROM board_comments WHERE post_id = board_posts.id) AS comments
@@ -134,7 +134,7 @@ router.post('/:id/dislike', authenticate, param('id').isInt(), validate, (req, r
 
 // Get comments for a post
 router.get('/:id/comments', param('id').isInt(), validate, (req, res, next) => {
-  const sql = `SELECT board_comments.*, users.username FROM board_comments
+  const sql = `SELECT board_comments.*, users.username, users.name, users.avatar_id, users.is_artist FROM board_comments
     JOIN users ON board_comments.user_id = users.id
     WHERE post_id = ? ORDER BY created_at ASC`;
   db.all(sql, [req.params.id], (err, rows) => {

--- a/tests/integration/api.test.js
+++ b/tests/integration/api.test.js
@@ -113,7 +113,11 @@ test('board post creation', async () => {
   const all = await context.get(`/board/user/${id}`);
   expect(all.ok()).toBeTruthy();
   const items = await all.json();
-  expect(items.find(p => p.headline === 'Test' && p.content === 'Hello board')).toBeTruthy();
+  const found = items.find(p => p.headline === 'Test' && p.content === 'Hello board');
+  expect(found).toBeTruthy();
+  expect(found.name).toBe('Dana');
+  expect(found.is_artist).toBe(0);
+  expect(found.avatar_id).toBeNull();
 });
 
 test('board post interactions', async () => {
@@ -149,10 +153,17 @@ test('board post interactions', async () => {
   const arr = await posts.json();
   const p = arr.find(x => x.id === id);
   expect(p.likes).toBe(1);
+  expect(p.name).toBe('Ed');
+  expect(p.is_artist).toBe(0);
+  expect(p.avatar_id).toBeNull();
 
   const comms = await context.get(`/board/${id}/comments`);
   const list = await comms.json();
-  expect(list.find(c => c.content === 'Nice')).toBeTruthy();
+  const com = list.find(c => c.content === 'Nice');
+  expect(com).toBeTruthy();
+  expect(com.name).toBe('Fay');
+  expect(com.is_artist).toBe(0);
+  expect(com.avatar_id).toBeNull();
 });
 
 test('merch and shows feed require following', async () => {


### PR DESCRIPTION
## Summary
- include user name, avatar and artist flag in board post and comment APIs
- display author avatars and types in board UI
- document new fields and test API responses

## Testing
- `npm start`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689caeca3680832dafedc17ea91c569c