### PR TITLE
Link trending posts to board details

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -134,13 +134,15 @@ function TrendingPosts({ auth }) {
     <div className="container mx-auto mt-8 border border-gray-200 rounded divide-y divide-gray-200">
       <h2 className="text-xl font-bold text-center p-4">Highlights from artists you follow.</h2>
       {posts.map(p => (
-        <div key={p.id} className="bg-white p-4">
-          <h3 className="font-bold">{p.headline}</h3>
-          <p className="text-sm">
-            {p.content.slice(0, 100)}{p.content.length > 100 ? '...' : ''}
-          </p>
-          <div className="text-xs text-gray-600 mt-2">{p.likes} likes</div>
-        </div>
+        <Link key={p.id} to={`/board/${p.id}`} className="block">
+          <div className="bg-white p-4">
+            <h3 className="font-bold">{p.headline}</h3>
+            <p className="text-sm">
+              {p.content.slice(0, 100)}{p.content.length > 100 ? '...' : ''}
+            </p>
+            <div className="text-xs text-gray-600 mt-2">{p.likes} likes</div>
+          </div>
+        </Link>
       ))}
     </div>
   );
@@ -875,6 +877,7 @@ function ShowsSection({ userId, auth, following }) {
 }
 
 function Board({ auth }) {
+  const { postId } = useParams();
   const [posts, setPosts] = React.useState([]);
   const [content, setContent] = React.useState('');
   const [headline, setHeadline] = React.useState('');
@@ -904,10 +907,17 @@ function Board({ auth }) {
         setNeedAuth(false);
         return r.json();
       })
-      .then(setPosts);
+      .then(d => {
+        setPosts(d);
+        if (postId) {
+          const id = parseInt(postId, 10);
+          setExpanded(id);
+          loadComments(id);
+        }
+      });
   };
 
-  React.useEffect(load, [auth.token]);
+  React.useEffect(load, [auth.token, postId]);
 
   const loadComments = id => {
     fetch(`/board/${id}/comments`)
@@ -1234,6 +1244,7 @@ function App() {
             <Route path="/messages" element={<Messages auth={auth} />} />
             <Route path="/notifications" element={<Notifications auth={auth} refreshUnread={loadUnread} />} />
             <Route path="/media" element={<Media auth={auth} />} />
+            <Route path="/board/:postId" element={<Board auth={auth} />} />
             <Route path="/board" element={<Board auth={auth} />} />
             <Route path="/shows" element={<Placeholder text="Show calendar" />} />
             <Route path="/merch" element={<Placeholder text="Merch shop" />} />

--- a/tests/integration/trending_board_navigation.test.js
+++ b/tests/integration/trending_board_navigation.test.js
@@ -1,0 +1,90 @@
+const http = require('http');
+const { test, expect, request } = require('@playwright/test');
+const { chromium } = require('playwright');
+
+let server;
+let api;
+let browser;
+let page;
+let baseURL;
+let skip = false;
+
+async function register(data) {
+  const res = await api.post('/auth/register', { data });
+  expect(res.ok()).toBeTruthy();
+  return res.json();
+}
+
+test.beforeAll(async () => {
+  process.env.DB_FILE = ':memory:';
+  const fs = require('fs');
+  const path = require('path');
+  const bin = path.join(__dirname, 'bin');
+  fs.mkdirSync(bin, { recursive: true });
+  const fake = path.join(bin, 'clamscan');
+  fs.writeFileSync(fake, '#!/bin/sh\nexit 0');
+  fs.chmodSync(fake, 0o755);
+  process.env.PATH = `${bin}:${process.env.PATH}`;
+
+  const app = require('../../app');
+  server = http.createServer(app);
+  await new Promise(resolve => server.listen(0, resolve));
+  baseURL = `http://localhost:${server.address().port}`;
+  api = await request.newContext({ baseURL });
+
+  try {
+    browser = await chromium.launch();
+    page = await browser.newPage();
+  } catch (e) {
+    skip = true;
+  }
+});
+
+test.afterAll(async () => {
+  await api.dispose();
+  if (browser) await browser.close();
+  server.close();
+});
+
+test('featured post opens board page with comments', async ({}, testInfo) => {
+  testInfo.skip(skip, 'browser not available');
+  const { token: artistToken, id: artistId } = await register({
+    name: 'Artist',
+    username: 'artist',
+    password: 'pw',
+    is_artist: true
+  });
+  const postRes = await api.post('/board', {
+    headers: { Authorization: `Bearer ${artistToken}` },
+    data: { headline: 'Hello', content: 'World' }
+  });
+  expect(postRes.ok()).toBeTruthy();
+  const post = await postRes.json();
+
+  const { token: fanToken, id: fanId } = await register({
+    name: 'Fan',
+    username: 'fan',
+    password: 'pw'
+  });
+  await api.post(`/follow/${artistId}`, {
+    headers: { Authorization: `Bearer ${fanToken}` }
+  });
+  await api.post(`/board/${post.id}/comments`, {
+    headers: { Authorization: `Bearer ${fanToken}` },
+    data: { content: 'Nice' }
+  });
+
+  await page.goto('about:blank');
+  await page.evaluate(({ t, uid }) => {
+    localStorage.setItem('token', t);
+    localStorage.setItem('userId', String(uid));
+    localStorage.setItem('isArtist', 'false');
+  }, { t: fanToken, uid: fanId });
+
+  await page.goto(`${baseURL}/`);
+  await page.waitForSelector(`text=${post.headline}`);
+  await page.click(`text=${post.headline}`);
+  await expect(page).toHaveURL(`${baseURL}/board/${post.id}`);
+  await page.waitForSelector('text=Nice');
+});
+


### PR DESCRIPTION
## Summary
- Make featured posts on the landing page clickable and link them to their board details
- Support `/board/:postId` route and auto-expand the linked post with its comments
- Add Playwright test to ensure clicking a featured post opens the correct board entry

## Testing
- `npm test` *(fails: browser unavailable for some tests)*
- `npm start`

------
https://chatgpt.com/codex/tasks/task_e_689cc38c01a8832d83eefcb720cd47bc